### PR TITLE
Add support for turning off entity decoding

### DIFF
--- a/packages/remark-parse/lib/defaults.js
+++ b/packages/remark-parse/lib/defaults.js
@@ -6,5 +6,6 @@ module.exports = {
   commonmark: false,
   footnotes: false,
   pedantic: false,
-  blocks: require('./block-elements.json')
+  blocks: require('./block-elements.json'),
+  decodeHtmlEntities: true
 };

--- a/packages/remark-parse/lib/tokenize/text.js
+++ b/packages/remark-parse/lib/tokenize/text.js
@@ -47,12 +47,20 @@ function text(eat, value, silent) {
   }
 
   subvalue = value.slice(0, min);
-  now = eat.now();
 
-  self.decode(subvalue, now, function (content, position, source) {
-    eat(source || content)({
-      type: 'text',
-      value: content
+  if (this.options.decodeHtmlEntities) {
+    now = eat.now();
+
+    self.decode(subvalue, now, function (content, position, source) {
+      eat(source || content)({
+        type: 'text',
+        value: content
+      });
     });
-  });
+  } else {
+    eat(subvalue)({
+      type: 'text',
+      value: subvalue
+    });
+  }
 }

--- a/packages/remark-parse/readme.md
+++ b/packages/remark-parse/readme.md
@@ -143,6 +143,17 @@ Pedantic mode (`boolean`, default: `false`) turns on:
 *   And pedantic mode removes less spaces in list-items (at most four,
     instead of the whole indent)
 
+##### `options.decodeHtmlEntities`
+
+```md
+&lt;div&gt;
+```
+
+Decode HTML entities (`boolean`, default: `true`)
+Allows HTML entity decoding to be switched off.  This may produce unexpected
+results with different configurations - only turn off if you know what you’re
+doing!
+
 ### `parse.Parser`
 
 Access to the [parser][], if you need it.

--- a/test/remark-parse.js
+++ b/test/remark-parse.js
@@ -63,6 +63,14 @@ test('remark().parse(file)', function (t) {
     'should throw when `options.pedantic` is not a boolean'
   );
 
+  t.throws(
+    function () {
+      remark().data('settings', {decodeHtmlEntities: {}}).parse('');
+    },
+    /options.decodeHtmlEntities/,
+    'should throw when `options.decodeHtmlEntities` is not a boolean'
+  );
+
   t.deepEqual(
     remark().data('settings', {position: false}).parse('<foo></foo>'),
     {

--- a/test/remark-process.js
+++ b/test/remark-process.js
@@ -22,6 +22,12 @@ test('remark().processSync(value)', function (t) {
     'should accept stringify options'
   );
 
+  t.equal(
+    remark().data('settings', {decodeHtmlEntities: false}).processSync('&lt;test&gt;').toString(),
+    '&amp;lt;test&amp;gt;\n',
+    'should optionally disable html entity decoding'
+  );
+
   t.throws(
     function () {
       remark().data('settings', {pedantic: true, listItemIndent: '1'}).processSync([


### PR DESCRIPTION
For Unified implementations that handle their own escaping, this is necessary for maintaining the decoded/encoded state of HTML entities in a markdown document.