### PR TITLE
remark-parse: parse link/img's attributes

### DIFF
--- a/packages/remark-parse/lib/tokenize/link.js
+++ b/packages/remark-parse/lib/tokenize/link.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var whitespace = require('is-whitespace-character');
+var parseAttr = require('md-attr-parser');
 var locate = require('../locate/link');
 
 module.exports = link;
@@ -42,6 +43,7 @@ function link(eat, value, silent) {
   var pedantic = self.options.pedantic;
   var commonmark = self.options.commonmark;
   var gfm = self.options.gfm;
+  var parsedAttr;
   var closed;
   var count;
   var opening;
@@ -367,6 +369,11 @@ function link(eat, value, silent) {
 
   subvalue += C_PAREN_CLOSE;
 
+  if (index + 1 < length && value.charAt(index + 1) === '{' && !gfm && !commonmark) {
+    parsedAttr = parseAttr(value, index + 1);
+    subvalue += parsedAttr.eaten;
+  }
+
   url = self.decode.raw(self.unescape(url), eat(beforeURL).test().end, {nonTerminated: false});
 
   if (title) {
@@ -379,6 +386,9 @@ function link(eat, value, silent) {
     title: title || null,
     url: url
   };
+  if (parsedAttr) {
+    node.data = {hProperties: parsedAttr.prop};
+  }
 
   if (isImage) {
     node.alt = self.decode.raw(self.unescape(content), now) || null;

--- a/packages/remark-parse/package.json
+++ b/packages/remark-parse/package.json
@@ -30,6 +30,7 @@
     "is-whitespace-character": "^1.0.0",
     "is-word-character": "^1.0.0",
     "markdown-escapes": "^1.0.0",
+    "md-attr-parser": "^1.1.0",
     "parse-entities": "^1.1.0",
     "repeat-string": "^1.5.4",
     "state-toggle": "^1.0.0",


### PR DESCRIPTION
Hi,

This pull request add a parser to link and image elements.

Images : 
```markdown
![alt](img){attrs} / ![alt](img){ height=50 }
```

Link   :
```markdown
[Hot babe with computer](https://rms.sexy){rel="external"}
```
At the moment it aims is to be used with remark-rehype to add attributes :
```html
<img alt="alt" src="img" height="50">

<a href="https://rms.sexy" rel="external">Hot babe with computer</a>
```

Not enabled when gfm is specified.


I'm open to any review. I think that this PL should be added as an option. ;)

Have a good day
<!--

Read the [contributing guidelines](https://github.com/remarkjs/remark/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
