### PR TITLE
remark-parse: don't parse the URL of autolink extension

### DIFF
--- a/packages/remark-parse/lib/tokenize/url.js
+++ b/packages/remark-parse/lib/tokenize/url.js
@@ -40,6 +40,7 @@ function url(eat, value, silent) {
   var queue;
   var parenCount;
   var nextCharacter;
+  var tokenizers;
   var exit;
 
   if (!self.options.gfm) {
@@ -132,7 +133,14 @@ function url(eat, value, silent) {
   }
 
   exit = self.enterLink();
+
+  /* Temporarily remove all tokenizers except text in url. */
+  tokenizers = self.inlineTokenizers;
+  self.inlineTokenizers = {text: tokenizers.text};
+
   content = self.tokenizeInline(content, eat.now());
+
+  self.inlineTokenizers = tokenizers;
   exit();
 
   return eat(subvalue)({


### PR DESCRIPTION
Hi,

This PR is about not parsing the URL of autolink extension URL (detect an URL and make it a link).

The modification of this commit comes from [auto-link.js](https://github.com/remarkjs/remark/blob/02297a5dea290751a0bfd766b4154ad403307b7e/packages/remark-parse/lib/tokenize/auto-link.js#L128-L136). Because they are both autolink, they should be treated the same.

Without this commit, sometimes we may have the title of the autolink (which is also the link) parsed.
Example : 
```
See that http://domain.org/this_is_good
```
Result : 
```
<p>See that <a href="http://domain.org/this_is_good">http://domain.org/this<em>is</em>good</a></p>
```

With this PR : 

```
<p>See that <a href="http://domain.org/this_is_good">http://domain.org/this_is_good</a></p>
```

Code used : 
```js
const unified = require('unified')
const remarkParse = require('remark-parse')
const stringify = require('rehype-stringify')
const remark2rehype = require('remark-rehype')


const raw = require('rehype-raw')

unified()
  .use(remarkParse, {pedantic: true})
  .use(remark2rehype) 
  .use(raw)
  .use(stringify)
  .process( `See that http://domain.org/this_is_good`, (err, file) => {
    console.log(String(file));
  } );
```

:two_hearts: 