### PR TITLE
Fix: pedantic remark-stringify can produce markdown that cannot be pedantically parsed

### DIFF
--- a/packages/remark-stringify/lib/visitors/emphasis.js
+++ b/packages/remark-stringify/lib/visitors/emphasis.js
@@ -19,10 +19,15 @@ function emphasis(node) {
   var marker = this.options.emphasis;
   var content = this.all(node).join('');
 
-  if (this.options.pedantic) {
-    if (marker === '_' && content.indexOf(marker) !== -1) {
-      marker = '*';
-    }
+  /* When in pedantic mode, prevent using underscore as the marker when
+   * there are underscores in the content.
+   */
+  if (
+    this.options.pedantic &&
+    marker === '_' &&
+    content.indexOf(marker) !== -1
+  ) {
+    marker = '*';
   }
 
   return marker + content + marker;

--- a/packages/remark-stringify/lib/visitors/emphasis.js
+++ b/packages/remark-stringify/lib/visitors/emphasis.js
@@ -9,8 +9,21 @@ module.exports = emphasis;
  * asterisk (`'*'`):
  *
  *     *foo*
+ *
+ * In `pedantic` mode, text which itself contains an underscore
+ * will cause the marker to default to an asterisk instead:
+ *
+ *     *foo_bar*
  */
 function emphasis(node) {
   var marker = this.options.emphasis;
-  return marker + this.all(node).join('') + marker;
+  var content = this.all(node).join('');
+
+  if (this.options.pedantic) {
+    if (marker === '_' && content.indexOf(marker) !== -1) {
+      marker = '*';
+    }
+  }
+
+  return marker + content + marker;
 }

--- a/test/remark-stringify.js
+++ b/test/remark-stringify.js
@@ -229,6 +229,32 @@ test('remark().stringify(ast, file)', function (t) {
     );
   });
 
+  t.test('emphasis in pedantic mode should support a variety of contained inline content', function (st) {
+    /* data-driven tests in the format: [name, input, expected] */
+    var tests = [
+      ["words with asterisks", "*inner content*", "_inner content_\n"],
+      ["words with underscores", "_inner content_", "_inner content_\n"],
+      ["links", "*[](http://some_url.com)*", "*[](http://some_url.com)*\n"],
+      ["underscores inside asterisks", "*inner content _with_ emphasis*", "*inner content _with_ emphasis*\n"],
+      ["asterisks inside underscores", "_inner content *with* emphasis_", "*inner content _with_ emphasis*\n"],
+      ["images", "*![](http://some_url.com/img.jpg)*", "*![](http://some_url.com/img.jpg)*\n"],
+      ["inline code with asterisks", "*content `with` code*", "_content `with` code_\n"],
+      ["inline code with underscores", "_content `with` code_", "_content `with` code_\n"],
+    ];
+
+    st.plan(tests.length);
+    tests.forEach(function (test) {
+      st.equal(
+        remark()
+          .use({settings: {pedantic: true}})
+          .processSync(test[1])
+          .toString(),
+        test[2],
+        test[0]
+      );
+    });
+  });
+
   t.test('should support `stringLength`', function (st) {
     st.plan(2);
 

--- a/test/remark-stringify.js
+++ b/test/remark-stringify.js
@@ -207,6 +207,28 @@ test('remark().stringify(ast, file)', function (t) {
     'should throw when `options.stringLength` is not a function'
   );
 
+  t.test('should handle underscores in emphasis in pedantic mode', function (st) {
+    st.plan(2);
+
+    var example = '*alpha_bravo*\n';
+
+    /* Without pedantic mode, emphasis always defaults to underscores */
+    st.equal(
+      remark().processSync(example).toString(),
+      '_alpha_bravo_\n',
+      'baseline'
+    );
+
+    /* With pedantic mode, emphasis will default to asterisks if the text to be
+     * emphasized contains underscores
+     */
+    st.equal(
+      remark().use({settings: {pedantic: true}}).processSync(example).toString(),
+      '*alpha\\_bravo*\n',
+      'pedantic'
+    );
+  });
+
   t.test('should support `stringLength`', function (st) {
     st.plan(2);
 

--- a/test/remark-stringify.js
+++ b/test/remark-stringify.js
@@ -230,16 +230,16 @@ test('remark().stringify(ast, file)', function (t) {
   });
 
   t.test('emphasis in pedantic mode should support a variety of contained inline content', function (st) {
-    /* data-driven tests in the format: [name, input, expected] */
+    /* Data-driven tests in the format: [name, input, expected] */
     var tests = [
-      ["words with asterisks", "*inner content*", "_inner content_\n"],
-      ["words with underscores", "_inner content_", "_inner content_\n"],
-      ["links", "*[](http://some_url.com)*", "*[](http://some_url.com)*\n"],
-      ["underscores inside asterisks", "*inner content _with_ emphasis*", "*inner content _with_ emphasis*\n"],
-      ["asterisks inside underscores", "_inner content *with* emphasis_", "*inner content _with_ emphasis*\n"],
-      ["images", "*![](http://some_url.com/img.jpg)*", "*![](http://some_url.com/img.jpg)*\n"],
-      ["inline code with asterisks", "*content `with` code*", "_content `with` code_\n"],
-      ["inline code with underscores", "_content `with` code_", "_content `with` code_\n"],
+      ['words with asterisks', '*inner content*', '_inner content_\n'],
+      ['words with underscores', '_inner content_', '_inner content_\n'],
+      ['links', '*[](http://some_url.com)*', '*[](http://some_url.com)*\n'],
+      ['underscores inside asterisks', '*inner content _with_ emphasis*', '*inner content _with_ emphasis*\n'],
+      ['asterisks inside underscores', '_inner content *with* emphasis_', '*inner content _with_ emphasis*\n'],
+      ['images', '*![](http://some_url.com/img.jpg)*', '*![](http://some_url.com/img.jpg)*\n'],
+      ['inline code with asterisks', '*content `with` code*', '_content `with` code_\n'],
+      ['inline code with underscores', '_content `with` code_', '_content `with` code_\n']
     ];
 
     st.plan(tests.length);


### PR DESCRIPTION
The specific problem this PR addresses is with underscores in emphasis. In pedantic mode, underscores in emphasis are only allowed if the emphasis is created with asterisks, not underscores:

-  `*alpha_bravo*` compiles to `<em>alpha_bravo</em>`
-  `_alpha_bravo_` compiles to `<em>alpha</em>bravo_`

Unfortunately, `remark-stringify` as it currently stands will stringify both inputs to `_alpha_bravo_`, meaning that the result of the chain:

    remark-parser -> remark-stringify -> remark-parser -> remark-to-rehype -> rehype-stringify

will be different from the result of the chain:

    remark-parser -> remark-to-rehype -> rehype-stringify

in pedantic mode.

The goal of this PR is to ensure that those two chains have identical outputs; or, put another way, to ensure that `remark-stringify` is not a destructive process, even in pedantic mode.