### PR TITLE
Add reference property on full references when different from identif…

### DIFF
--- a/packages/remark-parse/lib/tokenize/reference.js
+++ b/packages/remark-parse/lib/tokenize/reference.js
@@ -191,6 +191,10 @@ function reference(eat, value, silent) {
   };
 
   if (type === T_LINK || type === T_IMAGE) {
+    if (referenceType === 'full' && node.identifier !== identifier) {
+      node.reference = identifier;
+    }
+
     node.referenceType = referenceType;
   }
 

--- a/packages/remark-stringify/lib/util/label.js
+++ b/packages/remark-stringify/lib/util/label.js
@@ -10,7 +10,7 @@ module.exports = label;
  * changes. */
 function label(node) {
   var type = node.referenceType;
-  var value = type === 'full' ? node.identifier : '';
+  var value = type === 'full' ? (node.reference || node.identifier) : '';
 
   return type === 'shortcut' ? value : '[' + value + ']';
 }

--- a/test/fixtures/tree/links-reference-proto.json
+++ b/test/fixtures/tree/links-reference-proto.json
@@ -24,6 +24,7 @@
         {
           "type": "linkReference",
           "identifier": "tostring",
+          "reference": "toString",
           "referenceType": "full",
           "children": [
             {

--- a/test/remark-stringify.js
+++ b/test/remark-stringify.js
@@ -264,7 +264,7 @@ test('remark().stringify(ast, file)', function (t) {
       ['capitalized image references - full', '![alpha][Bravo]'],
       ['capitalized image references - collapsed', '![Bravo][]'],
       ['capitalized image references - shortcut', '![Bravo]'],
-      ['capitalized footnote references', '[^Alpha]'],
+      ['capitalized footnote references', '[^Alpha]']
     ];
 
     st.plan(tests.length);

--- a/test/remark-stringify.js
+++ b/test/remark-stringify.js
@@ -255,6 +255,30 @@ test('remark().stringify(ast, file)', function (t) {
     });
   });
 
+  t.test('undefined references should fallback to original', function (st) {
+    /* Data-driven tests in the format: [name, input, expected] */
+    var tests = [
+      ['capitalized link references - full', '[alpha][Bravo]'],
+      ['capitalized link references - collapsed', '[Bravo][]'],
+      ['capitalized link references - shortcut', '[Bravo]'],
+      ['capitalized image references - full', '![alpha][Bravo]'],
+      ['capitalized image references - collapsed', '![Bravo][]'],
+      ['capitalized image references - shortcut', '![Bravo]'],
+      ['capitalized footnote references', '[^Alpha]'],
+    ];
+
+    st.plan(tests.length);
+    tests.forEach(function (test) {
+      st.equal(
+        remark()
+          .processSync(test[1])
+          .toString(),
+        test[1] + '\n',
+        test[0]
+      );
+    });
+  });
+
   t.test('should support `stringLength`', function (st) {
     st.plan(2);
 


### PR DESCRIPTION
…ier.

* Change parse to add this property when needed to reconstruct the original
  input should the reference turn out to be undefined.
* Change parse test to handle this case
* Change stringify to prefer the reference property, if present, over
  the identifier property to produce markdown source.
* Add round-tripping tests for all undefined references.

<!--

Read the [contributing guidelines](https://github.com/remarkjs/remark/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
