### PR TITLE
[CommonMark] Fix: paragraph split detection in commonmark mode

### DIFF
--- a/packages/remark-parse/lib/tokenize/paragraph.js
+++ b/packages/remark-parse/lib/tokenize/paragraph.js
@@ -62,7 +62,7 @@ function paragraph(eat, value, silent) {
         position++;
       }
 
-      if (size >= TAB_SIZE) {
+      if (size >= TAB_SIZE && character !== C_NEWLINE) {
         index = value.indexOf(C_NEWLINE, index + 1);
         continue;
       }

--- a/test/fixtures/input/paragraphs-and-indentation.text
+++ b/test/fixtures/input/paragraphs-and-indentation.text
@@ -6,6 +6,10 @@ This is a paragraph
 This is a paragraph
    and this is further text
 
+This is a paragraph
+    
+and this is a new paragraph
+
 This is a paragraph with some asterisks
     ***
 

--- a/test/fixtures/tree/paragraphs-and-indentation.commonmark.json
+++ b/test/fixtures/tree/paragraphs-and-indentation.commonmark.json
@@ -120,7 +120,7 @@
       "children": [
         {
           "type": "text",
-          "value": "This is a paragraph with some asterisks\n    ***",
+          "value": "This is a paragraph\n",
           "position": {
             "start": {
               "line": 9,
@@ -129,12 +129,47 @@
             },
             "end": {
               "line": 10,
-              "column": 8,
-              "offset": 164
+              "column": 1,
+              "offset": 137
             },
             "indent": [
               1
             ]
+          }
+        },
+        {
+          "type": "break",
+          "position": {
+            "start": {
+              "line": 10,
+              "column": 1,
+              "offset": 137
+            },
+            "end": {
+              "line": 11,
+              "column": 1,
+              "offset": 142
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "text",
+          "value": "and this is a new paragraph",
+          "position": {
+            "start": {
+              "line": 11,
+              "column": 1,
+              "offset": 142
+            },
+            "end": {
+              "line": 11,
+              "column": 28,
+              "offset": 169
+            },
+            "indent": []
           }
         }
       ],
@@ -145,9 +180,49 @@
           "offset": 117
         },
         "end": {
-          "line": 10,
+          "line": 11,
+          "column": 28,
+          "offset": 169
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This is a paragraph with some asterisks\n    ***",
+          "position": {
+            "start": {
+              "line": 13,
+              "column": 1,
+              "offset": 171
+            },
+            "end": {
+              "line": 14,
+              "column": 8,
+              "offset": 218
+            },
+            "indent": [
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 13,
+          "column": 1,
+          "offset": 171
+        },
+        "end": {
+          "line": 14,
           "column": 8,
-          "offset": 164
+          "offset": 218
         },
         "indent": [
           1
@@ -162,14 +237,14 @@
           "value": "This is a paragraph followed by a horizontal rule",
           "position": {
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 1,
-              "offset": 166
+              "offset": 220
             },
             "end": {
-              "line": 12,
+              "line": 16,
               "column": 50,
-              "offset": 215
+              "offset": 269
             },
             "indent": []
           }
@@ -177,14 +252,14 @@
       ],
       "position": {
         "start": {
-          "line": 12,
+          "line": 16,
           "column": 1,
-          "offset": 166
+          "offset": 220
         },
         "end": {
-          "line": 12,
+          "line": 16,
           "column": 50,
-          "offset": 215
+          "offset": 269
         },
         "indent": []
       }
@@ -193,14 +268,14 @@
       "type": "thematicBreak",
       "position": {
         "start": {
-          "line": 13,
+          "line": 17,
           "column": 1,
-          "offset": 216
+          "offset": 270
         },
         "end": {
-          "line": 13,
+          "line": 17,
           "column": 7,
-          "offset": 222
+          "offset": 276
         },
         "indent": []
       }
@@ -214,14 +289,14 @@
           "value": "With lines.",
           "position": {
             "start": {
-              "line": 15,
+              "line": 19,
               "column": 3,
-              "offset": 226
+              "offset": 280
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 14,
-              "offset": 237
+              "offset": 291
             },
             "indent": []
           }
@@ -229,14 +304,14 @@
       ],
       "position": {
         "start": {
-          "line": 15,
+          "line": 19,
           "column": 1,
-          "offset": 224
+          "offset": 278
         },
         "end": {
-          "line": 15,
+          "line": 19,
           "column": 14,
-          "offset": 237
+          "offset": 291
         },
         "indent": []
       }
@@ -249,14 +324,14 @@
           "value": "This is a paragraph",
           "position": {
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 1,
-              "offset": 239
+              "offset": 293
             },
             "end": {
-              "line": 17,
+              "line": 21,
               "column": 20,
-              "offset": 258
+              "offset": 312
             },
             "indent": []
           }
@@ -264,14 +339,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 21,
           "column": 1,
-          "offset": 239
+          "offset": 293
         },
         "end": {
-          "line": 17,
+          "line": 21,
           "column": 20,
-          "offset": 258
+          "offset": 312
         },
         "indent": []
       }
@@ -282,14 +357,14 @@
       "value": "and this is code",
       "position": {
         "start": {
-          "line": 19,
+          "line": 23,
           "column": 1,
-          "offset": 260
+          "offset": 314
         },
         "end": {
-          "line": 19,
+          "line": 23,
           "column": 21,
-          "offset": 280
+          "offset": 334
         },
         "indent": []
       }
@@ -302,14 +377,14 @@
           "value": "This is a paragraph",
           "position": {
             "start": {
-              "line": 21,
+              "line": 25,
               "column": 1,
-              "offset": 282
+              "offset": 336
             },
             "end": {
-              "line": 21,
+              "line": 25,
               "column": 20,
-              "offset": 301
+              "offset": 355
             },
             "indent": []
           }
@@ -317,14 +392,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 25,
           "column": 1,
-          "offset": 282
+          "offset": 336
         },
         "end": {
-          "line": 21,
+          "line": 25,
           "column": 20,
-          "offset": 301
+          "offset": 355
         },
         "indent": []
       }
@@ -337,14 +412,14 @@
           "value": "   and this is a new paragraph",
           "position": {
             "start": {
-              "line": 23,
+              "line": 27,
               "column": 1,
-              "offset": 303
+              "offset": 357
             },
             "end": {
-              "line": 23,
+              "line": 27,
               "column": 31,
-              "offset": 333
+              "offset": 387
             },
             "indent": []
           }
@@ -352,14 +427,14 @@
       ],
       "position": {
         "start": {
-          "line": 23,
+          "line": 27,
           "column": 1,
-          "offset": 303
+          "offset": 357
         },
         "end": {
-          "line": 23,
+          "line": 27,
           "column": 31,
-          "offset": 333
+          "offset": 387
         },
         "indent": []
       }
@@ -372,14 +447,14 @@
           "value": "This is a paragraph with some asterisks in a code block",
           "position": {
             "start": {
-              "line": 25,
+              "line": 29,
               "column": 1,
-              "offset": 335
+              "offset": 389
             },
             "end": {
-              "line": 25,
+              "line": 29,
               "column": 56,
-              "offset": 390
+              "offset": 444
             },
             "indent": []
           }
@@ -387,14 +462,14 @@
       ],
       "position": {
         "start": {
-          "line": 25,
+          "line": 29,
           "column": 1,
-          "offset": 335
+          "offset": 389
         },
         "end": {
-          "line": 25,
+          "line": 29,
           "column": 56,
-          "offset": 390
+          "offset": 444
         },
         "indent": []
       }
@@ -405,14 +480,14 @@
       "value": "***",
       "position": {
         "start": {
-          "line": 27,
+          "line": 31,
           "column": 1,
-          "offset": 392
+          "offset": 446
         },
         "end": {
-          "line": 27,
+          "line": 31,
           "column": 8,
-          "offset": 399
+          "offset": 453
         },
         "indent": []
       }
@@ -425,14 +500,14 @@
           "value": "This is a paragraph followed by a horizontal rule",
           "position": {
             "start": {
-              "line": 29,
+              "line": 33,
               "column": 1,
-              "offset": 401
+              "offset": 455
             },
             "end": {
-              "line": 29,
+              "line": 33,
               "column": 50,
-              "offset": 450
+              "offset": 504
             },
             "indent": []
           }
@@ -440,14 +515,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 33,
           "column": 1,
-          "offset": 401
+          "offset": 455
         },
         "end": {
-          "line": 29,
+          "line": 33,
           "column": 50,
-          "offset": 450
+          "offset": 504
         },
         "indent": []
       }
@@ -456,14 +531,14 @@
       "type": "thematicBreak",
       "position": {
         "start": {
-          "line": 31,
+          "line": 35,
           "column": 1,
-          "offset": 452
+          "offset": 506
         },
         "end": {
-          "line": 31,
+          "line": 35,
           "column": 7,
-          "offset": 458
+          "offset": 512
         },
         "indent": []
       }
@@ -476,9 +551,9 @@
       "offset": 0
     },
     "end": {
-      "line": 33,
+      "line": 37,
       "column": 1,
-      "offset": 460
+      "offset": 514
     }
   }
 }

--- a/test/fixtures/tree/paragraphs-and-indentation.commonmark.json
+++ b/test/fixtures/tree/paragraphs-and-indentation.commonmark.json
@@ -120,7 +120,7 @@
       "children": [
         {
           "type": "text",
-          "value": "This is a paragraph\n",
+          "value": "This is a paragraph",
           "position": {
             "start": {
               "line": 9,
@@ -128,33 +128,31 @@
               "offset": 117
             },
             "end": {
-              "line": 10,
-              "column": 1,
-              "offset": 137
+              "line": 9,
+              "column": 20,
+              "offset": 136
             },
-            "indent": [
-              1
-            ]
+            "indent": []
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 117
         },
-        {
-          "type": "break",
-          "position": {
-            "start": {
-              "line": 10,
-              "column": 1,
-              "offset": 137
-            },
-            "end": {
-              "line": 11,
-              "column": 1,
-              "offset": 142
-            },
-            "indent": [
-              1
-            ]
-          }
+        "end": {
+          "line": 9,
+          "column": 20,
+          "offset": 136
         },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
         {
           "type": "text",
           "value": "and this is a new paragraph",
@@ -175,19 +173,16 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 142
         },
         "end": {
           "line": 11,
           "column": 28,
           "offset": 169
         },
-        "indent": [
-          1,
-          1
-        ]
+        "indent": []
       }
     },
     {

--- a/test/fixtures/tree/paragraphs-and-indentation.json
+++ b/test/fixtures/tree/paragraphs-and-indentation.json
@@ -120,7 +120,7 @@
       "children": [
         {
           "type": "text",
-          "value": "This is a paragraph with some asterisks",
+          "value": "This is a paragraph",
           "position": {
             "start": {
               "line": 9,
@@ -129,8 +129,8 @@
             },
             "end": {
               "line": 9,
-              "column": 40,
-              "offset": 156
+              "column": 20,
+              "offset": 136
             },
             "indent": []
           }
@@ -144,8 +144,78 @@
         },
         "end": {
           "line": 9,
+          "column": 20,
+          "offset": 136
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "and this is a new paragraph",
+          "position": {
+            "start": {
+              "line": 11,
+              "column": 1,
+              "offset": 142
+            },
+            "end": {
+              "line": 11,
+              "column": 28,
+              "offset": 169
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 11,
+          "column": 1,
+          "offset": 142
+        },
+        "end": {
+          "line": 11,
+          "column": 28,
+          "offset": 169
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This is a paragraph with some asterisks",
+          "position": {
+            "start": {
+              "line": 13,
+              "column": 1,
+              "offset": 171
+            },
+            "end": {
+              "line": 13,
+              "column": 40,
+              "offset": 210
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 13,
+          "column": 1,
+          "offset": 171
+        },
+        "end": {
+          "line": 13,
           "column": 40,
-          "offset": 156
+          "offset": 210
         },
         "indent": []
       }
@@ -156,14 +226,14 @@
       "value": "***",
       "position": {
         "start": {
-          "line": 10,
+          "line": 14,
           "column": 1,
-          "offset": 157
+          "offset": 211
         },
         "end": {
-          "line": 10,
+          "line": 14,
           "column": 8,
-          "offset": 164
+          "offset": 218
         },
         "indent": []
       }
@@ -176,14 +246,14 @@
           "value": "This is a paragraph followed by a horizontal rule",
           "position": {
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 1,
-              "offset": 166
+              "offset": 220
             },
             "end": {
-              "line": 12,
+              "line": 16,
               "column": 50,
-              "offset": 215
+              "offset": 269
             },
             "indent": []
           }
@@ -191,14 +261,14 @@
       ],
       "position": {
         "start": {
-          "line": 12,
+          "line": 16,
           "column": 1,
-          "offset": 166
+          "offset": 220
         },
         "end": {
-          "line": 12,
+          "line": 16,
           "column": 50,
-          "offset": 215
+          "offset": 269
         },
         "indent": []
       }
@@ -207,14 +277,14 @@
       "type": "thematicBreak",
       "position": {
         "start": {
-          "line": 13,
+          "line": 17,
           "column": 1,
-          "offset": 216
+          "offset": 270
         },
         "end": {
-          "line": 13,
+          "line": 17,
           "column": 7,
-          "offset": 222
+          "offset": 276
         },
         "indent": []
       }
@@ -228,14 +298,14 @@
           "value": "With lines.",
           "position": {
             "start": {
-              "line": 15,
+              "line": 19,
               "column": 3,
-              "offset": 226
+              "offset": 280
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 14,
-              "offset": 237
+              "offset": 291
             },
             "indent": []
           }
@@ -243,14 +313,14 @@
       ],
       "position": {
         "start": {
-          "line": 15,
+          "line": 19,
           "column": 1,
-          "offset": 224
+          "offset": 278
         },
         "end": {
-          "line": 15,
+          "line": 19,
           "column": 14,
-          "offset": 237
+          "offset": 291
         },
         "indent": []
       }
@@ -263,14 +333,14 @@
           "value": "This is a paragraph",
           "position": {
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 1,
-              "offset": 239
+              "offset": 293
             },
             "end": {
-              "line": 17,
+              "line": 21,
               "column": 20,
-              "offset": 258
+              "offset": 312
             },
             "indent": []
           }
@@ -278,14 +348,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 21,
           "column": 1,
-          "offset": 239
+          "offset": 293
         },
         "end": {
-          "line": 17,
+          "line": 21,
           "column": 20,
-          "offset": 258
+          "offset": 312
         },
         "indent": []
       }
@@ -296,14 +366,14 @@
       "value": "and this is code",
       "position": {
         "start": {
-          "line": 19,
+          "line": 23,
           "column": 1,
-          "offset": 260
+          "offset": 314
         },
         "end": {
-          "line": 19,
+          "line": 23,
           "column": 21,
-          "offset": 280
+          "offset": 334
         },
         "indent": []
       }
@@ -316,14 +386,14 @@
           "value": "This is a paragraph",
           "position": {
             "start": {
-              "line": 21,
+              "line": 25,
               "column": 1,
-              "offset": 282
+              "offset": 336
             },
             "end": {
-              "line": 21,
+              "line": 25,
               "column": 20,
-              "offset": 301
+              "offset": 355
             },
             "indent": []
           }
@@ -331,14 +401,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 25,
           "column": 1,
-          "offset": 282
+          "offset": 336
         },
         "end": {
-          "line": 21,
+          "line": 25,
           "column": 20,
-          "offset": 301
+          "offset": 355
         },
         "indent": []
       }
@@ -351,14 +421,14 @@
           "value": "   and this is a new paragraph",
           "position": {
             "start": {
-              "line": 23,
+              "line": 27,
               "column": 1,
-              "offset": 303
+              "offset": 357
             },
             "end": {
-              "line": 23,
+              "line": 27,
               "column": 31,
-              "offset": 333
+              "offset": 387
             },
             "indent": []
           }
@@ -366,14 +436,14 @@
       ],
       "position": {
         "start": {
-          "line": 23,
+          "line": 27,
           "column": 1,
-          "offset": 303
+          "offset": 357
         },
         "end": {
-          "line": 23,
+          "line": 27,
           "column": 31,
-          "offset": 333
+          "offset": 387
         },
         "indent": []
       }
@@ -386,14 +456,14 @@
           "value": "This is a paragraph with some asterisks in a code block",
           "position": {
             "start": {
-              "line": 25,
+              "line": 29,
               "column": 1,
-              "offset": 335
+              "offset": 389
             },
             "end": {
-              "line": 25,
+              "line": 29,
               "column": 56,
-              "offset": 390
+              "offset": 444
             },
             "indent": []
           }
@@ -401,14 +471,14 @@
       ],
       "position": {
         "start": {
-          "line": 25,
+          "line": 29,
           "column": 1,
-          "offset": 335
+          "offset": 389
         },
         "end": {
-          "line": 25,
+          "line": 29,
           "column": 56,
-          "offset": 390
+          "offset": 444
         },
         "indent": []
       }
@@ -419,14 +489,14 @@
       "value": "***",
       "position": {
         "start": {
-          "line": 27,
+          "line": 31,
           "column": 1,
-          "offset": 392
+          "offset": 446
         },
         "end": {
-          "line": 27,
+          "line": 31,
           "column": 8,
-          "offset": 399
+          "offset": 453
         },
         "indent": []
       }
@@ -439,14 +509,14 @@
           "value": "This is a paragraph followed by a horizontal rule",
           "position": {
             "start": {
-              "line": 29,
+              "line": 33,
               "column": 1,
-              "offset": 401
+              "offset": 455
             },
             "end": {
-              "line": 29,
+              "line": 33,
               "column": 50,
-              "offset": 450
+              "offset": 504
             },
             "indent": []
           }
@@ -454,14 +524,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 33,
           "column": 1,
-          "offset": 401
+          "offset": 455
         },
         "end": {
-          "line": 29,
+          "line": 33,
           "column": 50,
-          "offset": 450
+          "offset": 504
         },
         "indent": []
       }
@@ -470,14 +540,14 @@
       "type": "thematicBreak",
       "position": {
         "start": {
-          "line": 31,
+          "line": 35,
           "column": 1,
-          "offset": 452
+          "offset": 506
         },
         "end": {
-          "line": 31,
+          "line": 35,
           "column": 7,
-          "offset": 458
+          "offset": 512
         },
         "indent": []
       }
@@ -490,9 +560,9 @@
       "offset": 0
     },
     "end": {
-      "line": 33,
+      "line": 37,
       "column": 1,
-      "offset": 460
+      "offset": 514
     }
   }
 }

--- a/test/fixtures/tree/paragraphs-and-indentation.nogfm.commonmark.json
+++ b/test/fixtures/tree/paragraphs-and-indentation.nogfm.commonmark.json
@@ -120,7 +120,7 @@
       "children": [
         {
           "type": "text",
-          "value": "This is a paragraph with some asterisks\n    ***",
+          "value": "This is a paragraph\n",
           "position": {
             "start": {
               "line": 9,
@@ -129,12 +129,47 @@
             },
             "end": {
               "line": 10,
-              "column": 8,
-              "offset": 164
+              "column": 1,
+              "offset": 137
             },
             "indent": [
               1
             ]
+          }
+        },
+        {
+          "type": "break",
+          "position": {
+            "start": {
+              "line": 10,
+              "column": 1,
+              "offset": 137
+            },
+            "end": {
+              "line": 11,
+              "column": 1,
+              "offset": 142
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "text",
+          "value": "and this is a new paragraph",
+          "position": {
+            "start": {
+              "line": 11,
+              "column": 1,
+              "offset": 142
+            },
+            "end": {
+              "line": 11,
+              "column": 28,
+              "offset": 169
+            },
+            "indent": []
           }
         }
       ],
@@ -145,9 +180,49 @@
           "offset": 117
         },
         "end": {
-          "line": 10,
+          "line": 11,
+          "column": 28,
+          "offset": 169
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This is a paragraph with some asterisks\n    ***",
+          "position": {
+            "start": {
+              "line": 13,
+              "column": 1,
+              "offset": 171
+            },
+            "end": {
+              "line": 14,
+              "column": 8,
+              "offset": 218
+            },
+            "indent": [
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 13,
+          "column": 1,
+          "offset": 171
+        },
+        "end": {
+          "line": 14,
           "column": 8,
-          "offset": 164
+          "offset": 218
         },
         "indent": [
           1
@@ -162,14 +237,14 @@
           "value": "This is a paragraph followed by a horizontal rule",
           "position": {
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 1,
-              "offset": 166
+              "offset": 220
             },
             "end": {
-              "line": 12,
+              "line": 16,
               "column": 50,
-              "offset": 215
+              "offset": 269
             },
             "indent": []
           }
@@ -177,14 +252,14 @@
       ],
       "position": {
         "start": {
-          "line": 12,
+          "line": 16,
           "column": 1,
-          "offset": 166
+          "offset": 220
         },
         "end": {
-          "line": 12,
+          "line": 16,
           "column": 50,
-          "offset": 215
+          "offset": 269
         },
         "indent": []
       }
@@ -193,14 +268,14 @@
       "type": "thematicBreak",
       "position": {
         "start": {
-          "line": 13,
+          "line": 17,
           "column": 1,
-          "offset": 216
+          "offset": 270
         },
         "end": {
-          "line": 13,
+          "line": 17,
           "column": 7,
-          "offset": 222
+          "offset": 276
         },
         "indent": []
       }
@@ -214,14 +289,14 @@
           "value": "With lines.",
           "position": {
             "start": {
-              "line": 15,
+              "line": 19,
               "column": 3,
-              "offset": 226
+              "offset": 280
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 14,
-              "offset": 237
+              "offset": 291
             },
             "indent": []
           }
@@ -229,14 +304,14 @@
       ],
       "position": {
         "start": {
-          "line": 15,
+          "line": 19,
           "column": 1,
-          "offset": 224
+          "offset": 278
         },
         "end": {
-          "line": 15,
+          "line": 19,
           "column": 14,
-          "offset": 237
+          "offset": 291
         },
         "indent": []
       }
@@ -249,14 +324,14 @@
           "value": "This is a paragraph",
           "position": {
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 1,
-              "offset": 239
+              "offset": 293
             },
             "end": {
-              "line": 17,
+              "line": 21,
               "column": 20,
-              "offset": 258
+              "offset": 312
             },
             "indent": []
           }
@@ -264,14 +339,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 21,
           "column": 1,
-          "offset": 239
+          "offset": 293
         },
         "end": {
-          "line": 17,
+          "line": 21,
           "column": 20,
-          "offset": 258
+          "offset": 312
         },
         "indent": []
       }
@@ -282,14 +357,14 @@
       "value": "and this is code",
       "position": {
         "start": {
-          "line": 19,
+          "line": 23,
           "column": 1,
-          "offset": 260
+          "offset": 314
         },
         "end": {
-          "line": 19,
+          "line": 23,
           "column": 21,
-          "offset": 280
+          "offset": 334
         },
         "indent": []
       }
@@ -302,14 +377,14 @@
           "value": "This is a paragraph",
           "position": {
             "start": {
-              "line": 21,
+              "line": 25,
               "column": 1,
-              "offset": 282
+              "offset": 336
             },
             "end": {
-              "line": 21,
+              "line": 25,
               "column": 20,
-              "offset": 301
+              "offset": 355
             },
             "indent": []
           }
@@ -317,14 +392,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 25,
           "column": 1,
-          "offset": 282
+          "offset": 336
         },
         "end": {
-          "line": 21,
+          "line": 25,
           "column": 20,
-          "offset": 301
+          "offset": 355
         },
         "indent": []
       }
@@ -337,14 +412,14 @@
           "value": "   and this is a new paragraph",
           "position": {
             "start": {
-              "line": 23,
+              "line": 27,
               "column": 1,
-              "offset": 303
+              "offset": 357
             },
             "end": {
-              "line": 23,
+              "line": 27,
               "column": 31,
-              "offset": 333
+              "offset": 387
             },
             "indent": []
           }
@@ -352,14 +427,14 @@
       ],
       "position": {
         "start": {
-          "line": 23,
+          "line": 27,
           "column": 1,
-          "offset": 303
+          "offset": 357
         },
         "end": {
-          "line": 23,
+          "line": 27,
           "column": 31,
-          "offset": 333
+          "offset": 387
         },
         "indent": []
       }
@@ -372,14 +447,14 @@
           "value": "This is a paragraph with some asterisks in a code block",
           "position": {
             "start": {
-              "line": 25,
+              "line": 29,
               "column": 1,
-              "offset": 335
+              "offset": 389
             },
             "end": {
-              "line": 25,
+              "line": 29,
               "column": 56,
-              "offset": 390
+              "offset": 444
             },
             "indent": []
           }
@@ -387,14 +462,14 @@
       ],
       "position": {
         "start": {
-          "line": 25,
+          "line": 29,
           "column": 1,
-          "offset": 335
+          "offset": 389
         },
         "end": {
-          "line": 25,
+          "line": 29,
           "column": 56,
-          "offset": 390
+          "offset": 444
         },
         "indent": []
       }
@@ -405,14 +480,14 @@
       "value": "***",
       "position": {
         "start": {
-          "line": 27,
+          "line": 31,
           "column": 1,
-          "offset": 392
+          "offset": 446
         },
         "end": {
-          "line": 27,
+          "line": 31,
           "column": 8,
-          "offset": 399
+          "offset": 453
         },
         "indent": []
       }
@@ -425,14 +500,14 @@
           "value": "This is a paragraph followed by a horizontal rule",
           "position": {
             "start": {
-              "line": 29,
+              "line": 33,
               "column": 1,
-              "offset": 401
+              "offset": 455
             },
             "end": {
-              "line": 29,
+              "line": 33,
               "column": 50,
-              "offset": 450
+              "offset": 504
             },
             "indent": []
           }
@@ -440,14 +515,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 33,
           "column": 1,
-          "offset": 401
+          "offset": 455
         },
         "end": {
-          "line": 29,
+          "line": 33,
           "column": 50,
-          "offset": 450
+          "offset": 504
         },
         "indent": []
       }
@@ -456,14 +531,14 @@
       "type": "thematicBreak",
       "position": {
         "start": {
-          "line": 31,
+          "line": 35,
           "column": 1,
-          "offset": 452
+          "offset": 506
         },
         "end": {
-          "line": 31,
+          "line": 35,
           "column": 7,
-          "offset": 458
+          "offset": 512
         },
         "indent": []
       }
@@ -476,9 +551,9 @@
       "offset": 0
     },
     "end": {
-      "line": 33,
+      "line": 37,
       "column": 1,
-      "offset": 460
+      "offset": 514
     }
   }
 }

--- a/test/fixtures/tree/paragraphs-and-indentation.nogfm.commonmark.json
+++ b/test/fixtures/tree/paragraphs-and-indentation.nogfm.commonmark.json
@@ -120,7 +120,7 @@
       "children": [
         {
           "type": "text",
-          "value": "This is a paragraph\n",
+          "value": "This is a paragraph",
           "position": {
             "start": {
               "line": 9,
@@ -128,33 +128,31 @@
               "offset": 117
             },
             "end": {
-              "line": 10,
-              "column": 1,
-              "offset": 137
+              "line": 9,
+              "column": 20,
+              "offset": 136
             },
-            "indent": [
-              1
-            ]
+            "indent": []
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 117
         },
-        {
-          "type": "break",
-          "position": {
-            "start": {
-              "line": 10,
-              "column": 1,
-              "offset": 137
-            },
-            "end": {
-              "line": 11,
-              "column": 1,
-              "offset": 142
-            },
-            "indent": [
-              1
-            ]
-          }
+        "end": {
+          "line": 9,
+          "column": 20,
+          "offset": 136
         },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
         {
           "type": "text",
           "value": "and this is a new paragraph",
@@ -175,19 +173,16 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 142
         },
         "end": {
           "line": 11,
           "column": 28,
           "offset": 169
         },
-        "indent": [
-          1,
-          1
-        ]
+        "indent": []
       }
     },
     {

--- a/test/fixtures/tree/paragraphs-and-indentation.nogfm.json
+++ b/test/fixtures/tree/paragraphs-and-indentation.nogfm.json
@@ -120,7 +120,7 @@
       "children": [
         {
           "type": "text",
-          "value": "This is a paragraph with some asterisks",
+          "value": "This is a paragraph",
           "position": {
             "start": {
               "line": 9,
@@ -129,8 +129,8 @@
             },
             "end": {
               "line": 9,
-              "column": 40,
-              "offset": 156
+              "column": 20,
+              "offset": 136
             },
             "indent": []
           }
@@ -144,8 +144,78 @@
         },
         "end": {
           "line": 9,
+          "column": 20,
+          "offset": 136
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "and this is a new paragraph",
+          "position": {
+            "start": {
+              "line": 11,
+              "column": 1,
+              "offset": 142
+            },
+            "end": {
+              "line": 11,
+              "column": 28,
+              "offset": 169
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 11,
+          "column": 1,
+          "offset": 142
+        },
+        "end": {
+          "line": 11,
+          "column": 28,
+          "offset": 169
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This is a paragraph with some asterisks",
+          "position": {
+            "start": {
+              "line": 13,
+              "column": 1,
+              "offset": 171
+            },
+            "end": {
+              "line": 13,
+              "column": 40,
+              "offset": 210
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 13,
+          "column": 1,
+          "offset": 171
+        },
+        "end": {
+          "line": 13,
           "column": 40,
-          "offset": 156
+          "offset": 210
         },
         "indent": []
       }
@@ -156,14 +226,14 @@
       "value": "***",
       "position": {
         "start": {
-          "line": 10,
+          "line": 14,
           "column": 1,
-          "offset": 157
+          "offset": 211
         },
         "end": {
-          "line": 10,
+          "line": 14,
           "column": 8,
-          "offset": 164
+          "offset": 218
         },
         "indent": []
       }
@@ -176,14 +246,14 @@
           "value": "This is a paragraph followed by a horizontal rule",
           "position": {
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 1,
-              "offset": 166
+              "offset": 220
             },
             "end": {
-              "line": 12,
+              "line": 16,
               "column": 50,
-              "offset": 215
+              "offset": 269
             },
             "indent": []
           }
@@ -191,14 +261,14 @@
       ],
       "position": {
         "start": {
-          "line": 12,
+          "line": 16,
           "column": 1,
-          "offset": 166
+          "offset": 220
         },
         "end": {
-          "line": 12,
+          "line": 16,
           "column": 50,
-          "offset": 215
+          "offset": 269
         },
         "indent": []
       }
@@ -207,14 +277,14 @@
       "type": "thematicBreak",
       "position": {
         "start": {
-          "line": 13,
+          "line": 17,
           "column": 1,
-          "offset": 216
+          "offset": 270
         },
         "end": {
-          "line": 13,
+          "line": 17,
           "column": 7,
-          "offset": 222
+          "offset": 276
         },
         "indent": []
       }
@@ -228,14 +298,14 @@
           "value": "With lines.",
           "position": {
             "start": {
-              "line": 15,
+              "line": 19,
               "column": 3,
-              "offset": 226
+              "offset": 280
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 14,
-              "offset": 237
+              "offset": 291
             },
             "indent": []
           }
@@ -243,14 +313,14 @@
       ],
       "position": {
         "start": {
-          "line": 15,
+          "line": 19,
           "column": 1,
-          "offset": 224
+          "offset": 278
         },
         "end": {
-          "line": 15,
+          "line": 19,
           "column": 14,
-          "offset": 237
+          "offset": 291
         },
         "indent": []
       }
@@ -263,14 +333,14 @@
           "value": "This is a paragraph",
           "position": {
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 1,
-              "offset": 239
+              "offset": 293
             },
             "end": {
-              "line": 17,
+              "line": 21,
               "column": 20,
-              "offset": 258
+              "offset": 312
             },
             "indent": []
           }
@@ -278,14 +348,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 21,
           "column": 1,
-          "offset": 239
+          "offset": 293
         },
         "end": {
-          "line": 17,
+          "line": 21,
           "column": 20,
-          "offset": 258
+          "offset": 312
         },
         "indent": []
       }
@@ -296,14 +366,14 @@
       "value": "and this is code",
       "position": {
         "start": {
-          "line": 19,
+          "line": 23,
           "column": 1,
-          "offset": 260
+          "offset": 314
         },
         "end": {
-          "line": 19,
+          "line": 23,
           "column": 21,
-          "offset": 280
+          "offset": 334
         },
         "indent": []
       }
@@ -316,14 +386,14 @@
           "value": "This is a paragraph",
           "position": {
             "start": {
-              "line": 21,
+              "line": 25,
               "column": 1,
-              "offset": 282
+              "offset": 336
             },
             "end": {
-              "line": 21,
+              "line": 25,
               "column": 20,
-              "offset": 301
+              "offset": 355
             },
             "indent": []
           }
@@ -331,14 +401,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 25,
           "column": 1,
-          "offset": 282
+          "offset": 336
         },
         "end": {
-          "line": 21,
+          "line": 25,
           "column": 20,
-          "offset": 301
+          "offset": 355
         },
         "indent": []
       }
@@ -351,14 +421,14 @@
           "value": "   and this is a new paragraph",
           "position": {
             "start": {
-              "line": 23,
+              "line": 27,
               "column": 1,
-              "offset": 303
+              "offset": 357
             },
             "end": {
-              "line": 23,
+              "line": 27,
               "column": 31,
-              "offset": 333
+              "offset": 387
             },
             "indent": []
           }
@@ -366,14 +436,14 @@
       ],
       "position": {
         "start": {
-          "line": 23,
+          "line": 27,
           "column": 1,
-          "offset": 303
+          "offset": 357
         },
         "end": {
-          "line": 23,
+          "line": 27,
           "column": 31,
-          "offset": 333
+          "offset": 387
         },
         "indent": []
       }
@@ -386,14 +456,14 @@
           "value": "This is a paragraph with some asterisks in a code block",
           "position": {
             "start": {
-              "line": 25,
+              "line": 29,
               "column": 1,
-              "offset": 335
+              "offset": 389
             },
             "end": {
-              "line": 25,
+              "line": 29,
               "column": 56,
-              "offset": 390
+              "offset": 444
             },
             "indent": []
           }
@@ -401,14 +471,14 @@
       ],
       "position": {
         "start": {
-          "line": 25,
+          "line": 29,
           "column": 1,
-          "offset": 335
+          "offset": 389
         },
         "end": {
-          "line": 25,
+          "line": 29,
           "column": 56,
-          "offset": 390
+          "offset": 444
         },
         "indent": []
       }
@@ -419,14 +489,14 @@
       "value": "***",
       "position": {
         "start": {
-          "line": 27,
+          "line": 31,
           "column": 1,
-          "offset": 392
+          "offset": 446
         },
         "end": {
-          "line": 27,
+          "line": 31,
           "column": 8,
-          "offset": 399
+          "offset": 453
         },
         "indent": []
       }
@@ -439,14 +509,14 @@
           "value": "This is a paragraph followed by a horizontal rule",
           "position": {
             "start": {
-              "line": 29,
+              "line": 33,
               "column": 1,
-              "offset": 401
+              "offset": 455
             },
             "end": {
-              "line": 29,
+              "line": 33,
               "column": 50,
-              "offset": 450
+              "offset": 504
             },
             "indent": []
           }
@@ -454,14 +524,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 33,
           "column": 1,
-          "offset": 401
+          "offset": 455
         },
         "end": {
-          "line": 29,
+          "line": 33,
           "column": 50,
-          "offset": 450
+          "offset": 504
         },
         "indent": []
       }
@@ -470,14 +540,14 @@
       "type": "thematicBreak",
       "position": {
         "start": {
-          "line": 31,
+          "line": 35,
           "column": 1,
-          "offset": 452
+          "offset": 506
         },
         "end": {
-          "line": 31,
+          "line": 35,
           "column": 7,
-          "offset": 458
+          "offset": 512
         },
         "indent": []
       }
@@ -490,9 +560,9 @@
       "offset": 0
     },
     "end": {
-      "line": 33,
+      "line": 37,
       "column": 1,
-      "offset": 460
+      "offset": 514
     }
   }
 }


### PR DESCRIPTION
In commonmark, paragraphs can be split by blank lines _even if those lines contain whitespace_. ([example](https://spec.commonmark.org/dingus/?text=This%20is%20a%20paragraph%0A%20%20%20%20%0Aand%20this%20is%20a%20new%20paragraph))

Currently, in remark, paragraphs will be split by blank lines _only if those lines contain fewer than four characters worth of whitespace_, because the code to detect following indented content checks for an indentation but doesn't actually check for _content_.

The simple fix is to make sure that there is content following the indentation before absorbing the next paragraph.

I've added a new test fixture to cover this case; please let me know if that's not the way you'd prefer to test this change!