### PR TITLE
Stop creating paragraphs in tight lists

### DIFF
--- a/packages/remark-parse/lib/parser.js
+++ b/packages/remark-parse/lib/parser.js
@@ -16,6 +16,7 @@ function Parser(doc, file) {
   this.setOptions({});
 
   this.inList = false;
+  this.inTightList = false;
   this.inBlock = false;
   this.inLink = false;
   this.atStart = true;
@@ -37,6 +38,7 @@ proto.options = require('./defaults');
 /* Enter and exit helpers. */
 proto.exitStart = toggle('atStart', true);
 proto.enterList = toggle('inList', false);
+proto.enterTightList = toggle('inTightList', false);
 proto.enterLink = toggle('inLink', false);
 proto.enterBlock = toggle('inBlock', false);
 

--- a/packages/remark-parse/lib/tokenize/list.js
+++ b/packages/remark-parse/lib/tokenize/list.js
@@ -368,6 +368,9 @@ function listItem(ctx, value, position) {
   var checked = null;
   var task;
   var indent;
+  var loose;
+  var children;
+  var exit;
 
   value = fn.apply(null, arguments);
 
@@ -382,12 +385,24 @@ function listItem(ctx, value, position) {
     }
   }
 
+  loose = EXPRESSION_LOOSE_LIST_ITEM.test(value) ||
+    value.charAt(value.length - 1) === C_NEWLINE;
+
+  if (!loose) {
+    exit = ctx.enterTightList();
+  }
+
+  children = ctx.tokenizeBlock(value, position);
+
+  if (!loose) {
+    exit();
+  }
+
   return {
     type: 'listItem',
-    loose: EXPRESSION_LOOSE_LIST_ITEM.test(value) ||
-      value.charAt(value.length - 1) === C_NEWLINE,
+    loose: loose,
     checked: checked,
-    children: ctx.tokenizeBlock(value, position)
+    children: children
   };
 }
 

--- a/packages/remark-parse/lib/tokenize/paragraph.js
+++ b/packages/remark-parse/lib/tokenize/paragraph.js
@@ -28,6 +28,8 @@ function paragraph(eat, value, silent) {
   var character;
   var size;
   var now;
+  var children;
+  var add;
 
   while (index < length) {
     /* Eat everything if there’s no following newline. */
@@ -115,8 +117,19 @@ function paragraph(eat, value, silent) {
   now = eat.now();
   subvalue = trimTrailingLines(subvalue);
 
-  return eat(subvalue)({
+  children = self.tokenizeInline(subvalue, now);
+  add = eat(subvalue);
+
+  /* Paragraphs in a loose list are wrapped in <p> tags, while paragraphs in a
+   * tight list are not */
+  if (self.inTightList) {
+    return children.map(function (child) {
+      return add(child);
+    });
+  }
+
+  return add({
     type: 'paragraph',
-    children: self.tokenizeInline(subvalue, now)
+    children: children
   });
 }


### PR DESCRIPTION
See https://github.com/syntax-tree/mdast-util-to-hast/pull/23 for context.

This PR represents an opposing solution to the one presented in that PR; a solution in which the problematic paragraphs are never created in the first place, rather than being created and then discarded by the MDAST-to-HAST conversion.