### PR TITLE
doc: adds remark-redact to plugins list

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -138,6 +138,8 @@ Have a good idea for a new plugin?  Let’s [chat][gitter] and make it happen!
     — Syntax highlighting for
     [remark-react](https://github.com/mapbox/remark-react) through
     [lowlight](https://github.com/wooorm/lowlight)
+*   [`remark-redact`](https://github.com/seafoam6/remark-redact)
+    — Conceal portions of text with a █
 *   [`remark-reference-links`](https://github.com/remarkjs/remark-reference-links)
     — Transform links and images to references and definitions
 *   [`remark-rehype`](https://github.com/remarkjs/remark-rehype)


### PR DESCRIPTION
I'm super excited to have made my first npm module. Wanted to add the plugin to the list. 

Thanks remark!

<!--

Read the [contributing guidelines](https://github.com/remarkjs/remark/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
