### PR TITLE
Fix escaping of exclamation mark

### DIFF
--- a/packages/remark-stringify/lib/escape.js
+++ b/packages/remark-stringify/lib/escape.js
@@ -29,6 +29,7 @@ var underscore = '_'
 var graveAccent = '`'
 var verticalBar = '|'
 var tilde = '~'
+var exclamationMark = '!'
 
 var entities = {
   '<': '&lt;',
@@ -199,6 +200,15 @@ function factory(options) {
         prefix(ampersand + next.value) !== 0
       ) {
         escaped[escaped.length - 1] = one(ampersand)
+      }
+
+      // Escape exclamation marks immediately followed by links.
+      if (
+        next &&
+        next.type === 'link' &&
+        value.charAt(length - 1) === exclamationMark
+      ) {
+        escaped[escaped.length - 1] = one(exclamationMark)
       }
 
       // Escape double tildes in GFM.

--- a/packages/remark-stringify/test.js
+++ b/packages/remark-stringify/test.js
@@ -1300,6 +1300,12 @@ test('stringify escapes', function(t) {
     '`_` split over nodes (no word character after, #2)'
   )
 
+  t.equal(
+    toString(u('paragraph', [u('text', '!'), u('link', [u('text', 'a')])])),
+    '\\![a](<>)',
+    '! immediately followed by a link'
+  )
+
   t.end()
 })
 


### PR DESCRIPTION
There's a lot going on in escape.js and I'm not very used to working with parsers or compilers, but I *think* this covers it (I'm assuming here that if what follows the exclamation mark isn't an actual link node, it's probably not going to need escaping, but if I'm wrong on that, by all means let me know).