### PR TITLE
Fix project links in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,8 @@ contents][remark-toc], or [compile to man pages][remark-man].
 This repository contains the following projects:
 
 *   [`remark-parse`][parse] — Parse a markdown document to a syntax tree
-*   [`remark-stringify`][stringify] — Stringify a syntax tree to a markdown document
+*   [`remark-stringify`][stringify]
+    — Stringify a syntax tree to a markdown document
 *   [`remark`][api] — Programmatic interface with both `remark-parse` and `remark-stringify`
 *   [`remark-cli`][cli] — Command-line interface wrapping `remark`
 

--- a/readme.md
+++ b/readme.md
@@ -64,8 +64,8 @@ contents][remark-toc], or [compile to man pages][remark-man].
 
 This repository contains the following projects:
 
-*   [`remark-parse`][api] — Parse a markdown document to a syntax tree
-*   [`remark-stringify`][api] — Stringify a syntax tree to a markdown document
+*   [`remark-parse`][parse] — Parse a markdown document to a syntax tree
+*   [`remark-stringify`][stringify] — Stringify a syntax tree to a markdown document
 *   [`remark`][api] — Programmatic interface with both `remark-parse` and `remark-stringify`
 *   [`remark-cli`][cli] — Command-line interface wrapping `remark`
 
@@ -119,6 +119,10 @@ creating an issue in the [`remarkjs/ideas`][ideas] repository!
 [backers-badge]: https://opencollective.com/unified/backers/badge.svg
 
 [api]: https://github.com/remarkjs/remark/tree/master/packages/remark
+
+[parse]: https://github.com/remarkjs/remark/tree/master/packages/remark-parse
+
+[stringify]: https://github.com/remarkjs/remark/tree/master/packages/remark-stringify
 
 [cli]: https://github.com/remarkjs/remark/tree/master/packages/remark-cli
 


### PR DESCRIPTION
I noticed that the the parse and stringify modules link to the remark package instead of the corresponding packages.
I guess this is how it was supposed to be :)

<!--

Read the [contributing guidelines](https://github.com/remarkjs/remark/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
