### PR TITLE
Update readme.md

### DIFF
--- a/packages/remark-stringify/readme.md
+++ b/packages/remark-stringify/readme.md
@@ -81,6 +81,26 @@ var processor = unified()
 process.stdin.pipe(createStream(processor)).pipe(process.stdout)
 ```
 
+Here is how you parse, assign the tree to a variable, log it, then render it back to markdown and log it again:
+
+```js
+import unified from "unified";
+import markdown from "remark-parse";
+import stringify from "remark-stringify";
+
+const tree = unified()
+  .use(markdown)
+  .parse("# Some title");
+
+console.log(`tree = ${JSON.stringify(tree, null, 4)}`);
+
+const doc = unified()
+  .use(stringify)
+  .stringify(tree);
+
+console.log(`doc = ${doc}`);
+```
+
 ## Table of Contents
 
 *   [API](#api)


### PR DESCRIPTION
Let's supplement an example without pipes, so that people could clearly see how to turn AST into MD (string, not HTML), without chained functions. The current example is not very clear and I had to trawl unit tests to find this out.

<!--

Read the [contributing guidelines](https://github.com/remarkjs/remark/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
