### PR TITLE
Add `remark-capitalize` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -38,6 +38,9 @@ See [Creating plugins][create] below.
     – custom syntax for id’s, classes, and data attributes to spans of text
 *   [`remark-breaks`](https://github.com/remarkjs/remark-breaks)
     – support hard breaks without needing spaces (like on issues)
+*   [`remark-capitalize`](https://github.com/zeit/remark-capitalize)
+    – transform all titles with
+    [title.sh](https://github.com/zeit/title)
 *   [`remark-code-screenshot`](https://github.com/Swizec/remark-code-screenshot)
     – turn code blocks into carbon.now.sh screenshots
 *   [`remark-collapse`](https://github.com/Rokt33r/remark-collapse)


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/remarkjs/remark/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
