### PR TITLE
Add `remark-sectionize` to plugins.md

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -155,6 +155,9 @@ See [Creating plugins][create] below.
     — change absolute URLs to relative ones
 *   [`remark-retext`](https://github.com/remarkjs/remark-retext)
     — transform to [retext](https://github.com/retextjs/retext)
+*   [`remark-sectionize`](https://github.com/jake-low/remark-sectionize)
+    — wrap headings and subsequent content in section tags (new node type,
+    rehype compatible)
 *   [`remark-shortcodes`](https://github.com/djm/remark-shortcodes)
     — custom syntax Wordpress- and Hugo-like shortcodes (new node type)
 *   [`remark-slug`](https://github.com/remarkjs/remark-slug)


### PR DESCRIPTION
I created a remark plugin (`remark-sectionize` – [GitHub repo](https://github.com/jake-low/remark-sectionize), [NPM package](https://npmjs.com/package/remark-sectionize)) a few days ago and I thought I would add it to the plugins list. Details can be found in the repository's README, but basically it wraps each heading and the subsequent content in an HTML `<section>` element, which is handy if you want to style sections of your document with CSS. It's MIT-licensed.

I've added the phrases "new node type" (because I add mdast nodes with `type: "section"` to the document) and "rehype compatible" (because those nodes have a `data.hName` property). Please let me know if I've misinterpreted the meaning of these phrases.

P.S. thanks for maintaining remark! 🙂 