### PR TITLE
Clean leading tabs from new lines

### DIFF
--- a/packages/remark-parse/lib/parse.js
+++ b/packages/remark-parse/lib/parse.js
@@ -2,10 +2,13 @@
 
 var xtend = require('xtend')
 var removePosition = require('unist-util-remove-position')
+var vfile = require('vfile')
+var vfileLocation = require('vfile-location')
 
 module.exports = parse
 
 var lineFeed = '\n'
+var tab = '\t'
 var lineBreaksExpression = /\r\n|\r/g
 
 // Parse the bound file.
@@ -18,7 +21,15 @@ function parse() {
 
   // Clean non-unix newlines: `\r\n` and `\r` are all changed to `\n`.
   // This should not affect positional information.
-  value = value.replace(lineBreaksExpression, lineFeed)
+  var newValue = value.replace(lineBreaksExpression, lineFeed)
+  
+  newValue = cleanLeadingTabs(value)
+
+  if (newValue != value) {
+    value = newValue
+    // Need to reset the offset to match the updated values
+    self.toOffset = vfileLocation(vfile(value)).toOffset
+  }
 
   // BOM.
   if (value.charCodeAt(0) === 0xfeff) {
@@ -39,4 +50,27 @@ function parse() {
   }
 
   return node
+}
+
+// Replace any leading tabs on a newline with spaces.
+// This should not affect positional information.
+function cleanLeadingTabs(value) {
+  var occurence = value.indexOf(lineFeed + tab)
+  while (occurence != -1) {
+    var startOfTabs = occurence + 1
+    var endOfTabs = occurence + 2
+    var replacementString = "  "
+
+    // Find ALL leading tabs
+    while (value.substring(endOfTabs, endOfTabs + 1) == '\t') {
+      endOfTabs += 1
+      replacementString += "  "
+    }
+
+    // Replace tabs with spaces and start search over.
+    value = value.substr(0, startOfTabs) + replacementString + value.substr(endOfTabs)
+    occurence = value.indexOf(lineFeed + tab, occurence + 1)
+  }
+  
+  return value
 }

--- a/packages/remark-parse/test.js
+++ b/packages/remark-parse/test.js
@@ -164,6 +164,14 @@ test('remark().parse(file)', function(t) {
     }
   })
 
+  t.test('should handle leading tabs', function(st) {
+    var tabbedInput = `- 123\n\t\t- 456\t789\n\t\n`
+    var spacedInput = `- 123\n    - 456\t789\n  \n`
+    st.deepEqual(unified().use(parse).parse(tabbedInput), unified().use(parse).parse(spacedInput))
+
+    st.end()
+  })
+
   t.test('should warn about entities', function(st) {
     var filePath = path.join(
       'test',


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/remarkjs/remark/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->

Right now sublists aren't parsed when indented with tabs. This change causes all leading tabs on new lines to be treated as 2 spaces.

Closes #198 