### PR TITLE
Add remark-tree-sitter to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -180,7 +180,8 @@ See [Creating plugins][create] below.
     — add a table of contents
 *   [`remark-tree-sitter`](https://github.com/samlanning/remark-tree-sitter)
     — highlight code blocks in markdown files using
-    [Tree-sitter](https://tree-sitter.github.io/tree-sitter/) (rehype compatible)
+    [Tree-sitter](https://tree-sitter.github.io/tree-sitter/)
+    (rehype compatible)
 *   [`remark-unlink`](https://github.com/remarkjs/remark-unlink)
     — remove all links, references, and definitions
 *   [`remark-usage`](https://github.com/remarkjs/remark-usage)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -178,6 +178,9 @@ See [Creating plugins][create] below.
     — check and add the document title
 *   [`remark-toc`](https://github.com/remarkjs/remark-toc)
     — add a table of contents
+*   [`remark-tree-sitter`](https://github.com/samlanning/remark-tree-sitter)
+    — highlight code blocks in markdown files using
+    [Tree-sitter](https://tree-sitter.github.io/tree-sitter/) (rehype compatible)
 *   [`remark-unlink`](https://github.com/remarkjs/remark-unlink)
     — remove all links, references, and definitions
 *   [`remark-usage`](https://github.com/remarkjs/remark-usage)


### PR DESCRIPTION
I've had a lot of fun the past couple of days creating a plugin that uses Tree-sitter to syntax-highlight code blocks. Feel like I've now got it to a state where i'm comfortable with other using it, and was hoping it could be added to this list! :)

https://github.com/samlanning/remark-tree-sitter

Feedback very welcome!