### PR TITLE
Add remark-code-extra to list of plugins.

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -41,6 +41,8 @@ See [Creating plugins][create] below.
 *   [`remark-capitalize`](https://github.com/zeit/remark-capitalize)
     – transform all titles with
     [title.sh](https://github.com/zeit/title)
+*   [`remark-code-extra`](https://github.com/samlanning/remark-code-extra)
+    — Add to or transform the HTML output of code blocks (rehype compatible)
 *   [`remark-code-screenshot`](https://github.com/Swizec/remark-code-screenshot)
     – turn code blocks into carbon.now.sh screenshots
 *   [`remark-collapse`](https://github.com/Rokt33r/remark-collapse)


### PR DESCRIPTION
Created another plugin that I hope is welcome :)

This one allows users to add extra HTML to code snippets. My main motivation for this was wanting to add links to our query console from QL code snippets on the Semmle blog.