### PR TITLE
Merge blockquotes in gfm mode

### DIFF
--- a/packages/remark-parse/lib/tokenizer.js
+++ b/packages/remark-parse/lib/tokenizer.js
@@ -304,7 +304,7 @@ function mergeText(prev, node) {
 
 // Merge two blockquotes: `node` into `prev`, unless in CommonMark mode.
 function mergeBlockquote(prev, node) {
-  if (this.options.commonmark) {
+  if (this.options.commonmark || this.options.gfm) {
     return node
   }
 

--- a/packages/remark-parse/lib/tokenizer.js
+++ b/packages/remark-parse/lib/tokenizer.js
@@ -302,7 +302,7 @@ function mergeText(prev, node) {
   return prev
 }
 
-// Merge two blockquotes: `node` into `prev`, unless in CommonMark mode.
+// Merge two blockquotes: `node` into `prev`, unless in CommonMark or gfm modes.
 function mergeBlockquote(prev, node) {
   if (this.options.commonmark || this.options.gfm) {
     return node

--- a/test/fixtures/input/blockquotes.text
+++ b/test/fixtures/input/blockquotes.text
@@ -1,3 +1,3 @@
 > This is a blockquote.
 
-> This is, in commonmark mode, another blockquote.
+> This is, in commonmark mode and gfm mode, another blockquote.

--- a/test/fixtures/tree/blockquotes.commonmark.json
+++ b/test/fixtures/tree/blockquotes.commonmark.json
@@ -62,7 +62,7 @@
           "children": [
             {
               "type": "text",
-              "value": "This is, in commonmark mode, another blockquote.",
+              "value": "This is, in commonmark mode and gfm mode, another blockquote.",
               "position": {
                 "start": {
                   "line": 3,
@@ -71,8 +71,8 @@
                 },
                 "end": {
                   "line": 3,
-                  "column": 51,
-                  "offset": 75
+                  "column": 64,
+                  "offset": 88
                 },
                 "indent": []
               }
@@ -86,8 +86,8 @@
             },
             "end": {
               "line": 3,
-              "column": 51,
-              "offset": 75
+              "column": 64,
+              "offset": 88
             },
             "indent": []
           }
@@ -101,8 +101,8 @@
         },
         "end": {
           "line": 3,
-          "column": 51,
-          "offset": 75
+          "column": 64,
+          "offset": 88
         },
         "indent": []
       }
@@ -117,7 +117,7 @@
     "end": {
       "line": 4,
       "column": 1,
-      "offset": 76
+      "offset": 89
     }
   }
 }

--- a/test/fixtures/tree/blockquotes.json
+++ b/test/fixtures/tree/blockquotes.json
@@ -38,13 +38,31 @@
             },
             "indent": []
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
         },
+        "end": {
+          "line": 1,
+          "column": 24,
+          "offset": 23
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
             {
               "type": "text",
-              "value": "This is, in commonmark mode, another blockquote.",
+              "value": "This is, in commonmark mode and gfm mode, another blockquote.",
               "position": {
                 "start": {
                   "line": 3,
@@ -53,8 +71,8 @@
                 },
                 "end": {
                   "line": 3,
-                  "column": 51,
-                  "offset": 75
+                  "column": 64,
+                  "offset": 88
                 },
                 "indent": []
               }
@@ -68,8 +86,8 @@
             },
             "end": {
               "line": 3,
-              "column": 51,
-              "offset": 75
+              "column": 64,
+              "offset": 88
             },
             "indent": []
           }
@@ -77,19 +95,16 @@
       ],
       "position": {
         "start": {
-          "line": 1,
+          "line": 3,
           "column": 1,
-          "offset": 0
+          "offset": 25
         },
         "end": {
           "line": 3,
-          "column": 51,
-          "offset": 75
+          "column": 64,
+          "offset": 88
         },
-        "indent": [
-          1,
-          1
-        ]
+        "indent": []
       }
     }
   ],
@@ -102,7 +117,7 @@
     "end": {
       "line": 4,
       "column": 1,
-      "offset": 76
+      "offset": 89
     }
   }
 }

--- a/test/fixtures/tree/entities-advanced.json
+++ b/test/fixtures/tree/entities-advanced.json
@@ -38,7 +38,25 @@
             },
             "indent": []
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
         },
+        "end": {
+          "line": 1,
+          "column": 54,
+          "offset": 53
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -73,7 +91,25 @@
             },
             "indent": []
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 1,
+          "offset": 55
         },
+        "end": {
+          "line": 3,
+          "column": 65,
+          "offset": 119
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "code",
           "lang": "some©language",
@@ -95,7 +131,28 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1,
+          "offset": 121
         },
+        "end": {
+          "line": 7,
+          "column": 6,
+          "offset": 167
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -201,7 +258,25 @@
             },
             "indent": []
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 169
         },
+        "end": {
+          "line": 9,
+          "column": 55,
+          "offset": 223
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -324,7 +399,25 @@
             },
             "indent": []
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 11,
+          "column": 1,
+          "offset": 225
         },
+        "end": {
+          "line": 11,
+          "column": 57,
+          "offset": 281
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -434,7 +527,27 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 13,
+          "column": 1,
+          "offset": 283
         },
+        "end": {
+          "line": 14,
+          "column": 41,
+          "offset": 344
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -546,7 +659,28 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 16,
+          "column": 1,
+          "offset": 346
         },
+        "end": {
+          "line": 18,
+          "column": 25,
+          "offset": 414
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -612,9 +746,9 @@
       ],
       "position": {
         "start": {
-          "line": 1,
+          "line": 20,
           "column": 1,
-          "offset": 0
+          "offset": 416
         },
         "end": {
           "line": 23,
@@ -622,25 +756,6 @@
           "offset": 486
         },
         "indent": [
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
           1,
           1,
           1
@@ -725,7 +840,28 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 27,
+          "column": 1,
+          "offset": 493
         },
+        "end": {
+          "line": 29,
+          "column": 25,
+          "offset": 562
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -786,7 +922,28 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 31,
+          "column": 1,
+          "offset": 564
         },
+        "end": {
+          "line": 33,
+          "column": 8,
+          "offset": 596
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -985,7 +1142,27 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 35,
+          "column": 1,
+          "offset": 598
         },
+        "end": {
+          "line": 36,
+          "column": 13,
+          "offset": 656
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -1196,9 +1373,9 @@
       ],
       "position": {
         "start": {
-          "line": 27,
+          "line": 38,
           "column": 1,
-          "offset": 493
+          "offset": 658
         },
         "end": {
           "line": 41,
@@ -1206,17 +1383,6 @@
           "offset": 724
         },
         "indent": [
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
           1,
           1,
           1
@@ -1314,7 +1480,27 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 45,
+          "column": 1,
+          "offset": 731
         },
+        "end": {
+          "line": 46,
+          "column": 15,
+          "offset": 809
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "code",
           "lang": null,
@@ -1337,20 +1523,16 @@
       ],
       "position": {
         "start": {
-          "line": 45,
+          "line": 48,
           "column": 1,
-          "offset": 731
+          "offset": 811
         },
         "end": {
           "line": 48,
           "column": 22,
           "offset": 832
         },
-        "indent": [
-          1,
-          1,
-          1
-        ]
+        "indent": []
       }
     }
   ],

--- a/test/fixtures/tree/entities-advanced.pedantic.json
+++ b/test/fixtures/tree/entities-advanced.pedantic.json
@@ -38,7 +38,25 @@
             },
             "indent": []
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
         },
+        "end": {
+          "line": 1,
+          "column": 54,
+          "offset": 53
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -73,7 +91,25 @@
             },
             "indent": []
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 1,
+          "offset": 55
         },
+        "end": {
+          "line": 3,
+          "column": 65,
+          "offset": 119
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "code",
           "lang": "some©language",
@@ -95,7 +131,28 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1,
+          "offset": 121
         },
+        "end": {
+          "line": 7,
+          "column": 6,
+          "offset": 167
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -201,7 +258,25 @@
             },
             "indent": []
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 169
         },
+        "end": {
+          "line": 9,
+          "column": 55,
+          "offset": 223
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -324,7 +399,25 @@
             },
             "indent": []
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 11,
+          "column": 1,
+          "offset": 225
         },
+        "end": {
+          "line": 11,
+          "column": 57,
+          "offset": 281
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -434,7 +527,27 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 13,
+          "column": 1,
+          "offset": 283
         },
+        "end": {
+          "line": 14,
+          "column": 41,
+          "offset": 344
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -546,7 +659,28 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 16,
+          "column": 1,
+          "offset": 346
         },
+        "end": {
+          "line": 18,
+          "column": 25,
+          "offset": 414
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -612,9 +746,9 @@
       ],
       "position": {
         "start": {
-          "line": 1,
+          "line": 20,
           "column": 1,
-          "offset": 0
+          "offset": 416
         },
         "end": {
           "line": 23,
@@ -622,25 +756,6 @@
           "offset": 486
         },
         "indent": [
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
           1,
           1,
           1
@@ -725,7 +840,28 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 27,
+          "column": 1,
+          "offset": 493
         },
+        "end": {
+          "line": 29,
+          "column": 25,
+          "offset": 562
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -786,7 +922,28 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 31,
+          "column": 1,
+          "offset": 564
         },
+        "end": {
+          "line": 33,
+          "column": 8,
+          "offset": 596
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -985,7 +1142,27 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 35,
+          "column": 1,
+          "offset": 598
         },
+        "end": {
+          "line": 36,
+          "column": 13,
+          "offset": 656
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "paragraph",
           "children": [
@@ -1196,9 +1373,9 @@
       ],
       "position": {
         "start": {
-          "line": 27,
+          "line": 38,
           "column": 1,
-          "offset": 493
+          "offset": 658
         },
         "end": {
           "line": 41,
@@ -1206,17 +1383,6 @@
           "offset": 724
         },
         "indent": [
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
           1,
           1,
           1
@@ -1314,7 +1480,27 @@
               3
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 45,
+          "column": 1,
+          "offset": 731
         },
+        "end": {
+          "line": 46,
+          "column": 15,
+          "offset": 809
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "code",
           "lang": null,
@@ -1337,20 +1523,16 @@
       ],
       "position": {
         "start": {
-          "line": 45,
+          "line": 48,
           "column": 1,
-          "offset": 731
+          "offset": 811
         },
         "end": {
           "line": 48,
           "column": 22,
           "offset": 832
         },
-        "indent": [
-          1,
-          1,
-          1
-        ]
+        "indent": []
       }
     }
   ],

--- a/test/fixtures/tree/heading-in-blockquote.json
+++ b/test/fixtures/tree/heading-in-blockquote.json
@@ -135,7 +135,27 @@
               1
             ]
           }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 6,
+          "column": 1,
+          "offset": 58
         },
+        "end": {
+          "line": 7,
+          "column": 4,
+          "offset": 123
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "blockquote",
+      "children": [
         {
           "type": "heading",
           "depth": 2,
@@ -177,9 +197,9 @@
       ],
       "position": {
         "start": {
-          "line": 6,
+          "line": 9,
           "column": 1,
-          "offset": 58
+          "offset": 125
         },
         "end": {
           "line": 10,
@@ -187,9 +207,6 @@
           "offset": 158
         },
         "indent": [
-          1,
-          1,
-          1,
           1
         ]
       }


### PR DESCRIPTION
Hi,

The PR relative to #415.

Update some fixtures because gfm is by default.
The simplest fixtures is also updated to relate change ("in commonmark mode this block is not merged" become "in commonmark mode and gfm mode...").

That's all :D 