### PR TITLE
Fix tilde, backtick in fenced code info string

### DIFF
--- a/packages/remark-parse/lib/tokenize/code-fenced.js
+++ b/packages/remark-parse/lib/tokenize/code-fenced.js
@@ -100,8 +100,7 @@ function fencedCode(eat, value, silent) {
 
     if (
       character === lineFeed ||
-      character === tilde ||
-      character === graveAccent
+      (marker === graveAccent && character === marker)
     ) {
       break
     }

--- a/packages/remark-stringify/lib/visitors/code.js
+++ b/packages/remark-stringify/lib/visitors/code.js
@@ -8,6 +8,8 @@ module.exports = code
 
 var lineFeed = '\n'
 var space = ' '
+var tilde = '~'
+var graveAccent = '`'
 
 // Stringify code.
 // Creates indented code when:
@@ -71,6 +73,12 @@ function code(node, parent) {
     }
 
     return pad(value, 1)
+  }
+
+  // Backticks in the info string don’t work with backtick fenced code.
+  // Backticks (and tildes) are fine in tilde fenced code.
+  if (marker === graveAccent && info.indexOf(graveAccent) !== -1) {
+    marker = tilde
   }
 
   fence = repeat(marker, Math.max(streak(value, marker) + 1, 3))

--- a/test/fixtures/input/fenced-code-info-with-marker.text
+++ b/test/fixtures/input/fenced-code-info-with-marker.text
@@ -1,0 +1,28 @@
+If the info string comes after a backtick fence, it may not contain any backtick
+characters.
+The reason for this restriction is that otherwise some inline code would be
+incorrectly interpreted as the beginning of a fenced code block.
+
+Tildes in info strings are fine:
+
+```js filename=~/.bashrc
+console.log(1)
+```
+
+Tildes in info strings are fine after tilde fences:
+
+~~~js filename=~/.bashrc
+console.log(1)
+~~~
+
+Backticks in info strings are fine after tilde fences:
+
+~~~js title=`.bashrc`
+console.log(1)
+~~~
+
+Backticks in info strings are **not** fine after backtick fences:
+
+```js title=`.bashrc`
+console.log(1)
+```

--- a/test/fixtures/tree/fenced-code-info-with-marker.json
+++ b/test/fixtures/tree/fenced-code-info-with-marker.json
@@ -1,0 +1,446 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "If the info string comes after a backtick fence, it may not contain any backtick\ncharacters.\nThe reason for this restriction is that otherwise some inline code would be\nincorrectly interpreted as the beginning of a fenced code block.",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 4,
+              "column": 65,
+              "offset": 233
+            },
+            "indent": [
+              1,
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 65,
+          "offset": 233
+        },
+        "indent": [
+          1,
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Tildes in info strings are fine:",
+          "position": {
+            "start": {
+              "line": 6,
+              "column": 1,
+              "offset": 235
+            },
+            "end": {
+              "line": 6,
+              "column": 33,
+              "offset": 267
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 6,
+          "column": 1,
+          "offset": 235
+        },
+        "end": {
+          "line": 6,
+          "column": 33,
+          "offset": 267
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "code",
+      "lang": "js",
+      "meta": "filename=~/.bashrc",
+      "value": "console.log(1)",
+      "position": {
+        "start": {
+          "line": 8,
+          "column": 1,
+          "offset": 269
+        },
+        "end": {
+          "line": 10,
+          "column": 4,
+          "offset": 312
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Tildes in info strings are fine after tilde fences:",
+          "position": {
+            "start": {
+              "line": 12,
+              "column": 1,
+              "offset": 314
+            },
+            "end": {
+              "line": 12,
+              "column": 52,
+              "offset": 365
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 12,
+          "column": 1,
+          "offset": 314
+        },
+        "end": {
+          "line": 12,
+          "column": 52,
+          "offset": 365
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "code",
+      "lang": "js",
+      "meta": "filename=~/.bashrc",
+      "value": "console.log(1)",
+      "position": {
+        "start": {
+          "line": 14,
+          "column": 1,
+          "offset": 367
+        },
+        "end": {
+          "line": 16,
+          "column": 4,
+          "offset": 410
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Backticks in info strings are fine after tilde fences:",
+          "position": {
+            "start": {
+              "line": 18,
+              "column": 1,
+              "offset": 412
+            },
+            "end": {
+              "line": 18,
+              "column": 55,
+              "offset": 466
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 18,
+          "column": 1,
+          "offset": 412
+        },
+        "end": {
+          "line": 18,
+          "column": 55,
+          "offset": 466
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "code",
+      "lang": "js",
+      "meta": "title=`.bashrc`",
+      "value": "console.log(1)",
+      "position": {
+        "start": {
+          "line": 20,
+          "column": 1,
+          "offset": 468
+        },
+        "end": {
+          "line": 22,
+          "column": 4,
+          "offset": 508
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Backticks in info strings are ",
+          "position": {
+            "start": {
+              "line": 24,
+              "column": 1,
+              "offset": 510
+            },
+            "end": {
+              "line": 24,
+              "column": 31,
+              "offset": 540
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "strong",
+          "children": [
+            {
+              "type": "text",
+              "value": "not",
+              "position": {
+                "start": {
+                  "line": 24,
+                  "column": 33,
+                  "offset": 542
+                },
+                "end": {
+                  "line": 24,
+                  "column": 36,
+                  "offset": 545
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 24,
+              "column": 31,
+              "offset": 540
+            },
+            "end": {
+              "line": 24,
+              "column": 38,
+              "offset": 547
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " fine after backtick fences:",
+          "position": {
+            "start": {
+              "line": 24,
+              "column": 38,
+              "offset": 547
+            },
+            "end": {
+              "line": 24,
+              "column": 66,
+              "offset": 575
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 24,
+          "column": 1,
+          "offset": 510
+        },
+        "end": {
+          "line": 24,
+          "column": 66,
+          "offset": 575
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "`",
+          "position": {
+            "start": {
+              "line": 26,
+              "column": 1,
+              "offset": 577
+            },
+            "end": {
+              "line": 26,
+              "column": 2,
+              "offset": 578
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": "",
+          "position": {
+            "start": {
+              "line": 26,
+              "column": 2,
+              "offset": 578
+            },
+            "end": {
+              "line": 26,
+              "column": 4,
+              "offset": 580
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "js title=",
+          "position": {
+            "start": {
+              "line": 26,
+              "column": 4,
+              "offset": 580
+            },
+            "end": {
+              "line": 26,
+              "column": 13,
+              "offset": 589
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": ".bashrc",
+          "position": {
+            "start": {
+              "line": 26,
+              "column": 13,
+              "offset": 589
+            },
+            "end": {
+              "line": 26,
+              "column": 22,
+              "offset": 598
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "\nconsole.log(1)",
+          "position": {
+            "start": {
+              "line": 26,
+              "column": 22,
+              "offset": 598
+            },
+            "end": {
+              "line": 27,
+              "column": 15,
+              "offset": 613
+            },
+            "indent": [
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 26,
+          "column": 1,
+          "offset": 577
+        },
+        "end": {
+          "line": 27,
+          "column": 15,
+          "offset": 613
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "code",
+      "lang": null,
+      "meta": null,
+      "value": "",
+      "position": {
+        "start": {
+          "line": 28,
+          "column": 1,
+          "offset": 614
+        },
+        "end": {
+          "line": 29,
+          "column": 1,
+          "offset": 618
+        },
+        "indent": [
+          1
+        ]
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 29,
+      "column": 1,
+      "offset": 618
+    }
+  }
+}

--- a/test/fixtures/tree/fenced-code-info-with-marker.nogfm.json
+++ b/test/fixtures/tree/fenced-code-info-with-marker.nogfm.json
@@ -1,0 +1,450 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "If the info string comes after a backtick fence, it may not contain any backtick\ncharacters.\nThe reason for this restriction is that otherwise some inline code would be\nincorrectly interpreted as the beginning of a fenced code block.",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 4,
+              "column": 65,
+              "offset": 233
+            },
+            "indent": [
+              1,
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 65,
+          "offset": 233
+        },
+        "indent": [
+          1,
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Tildes in info strings are fine:",
+          "position": {
+            "start": {
+              "line": 6,
+              "column": 1,
+              "offset": 235
+            },
+            "end": {
+              "line": 6,
+              "column": 33,
+              "offset": 267
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 6,
+          "column": 1,
+          "offset": 235
+        },
+        "end": {
+          "line": 6,
+          "column": 33,
+          "offset": 267
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "inlineCode",
+          "value": "js filename=~/.bashrc\nconsole.log(1)",
+          "position": {
+            "start": {
+              "line": 8,
+              "column": 1,
+              "offset": 269
+            },
+            "end": {
+              "line": 10,
+              "column": 4,
+              "offset": 312
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 8,
+          "column": 1,
+          "offset": 269
+        },
+        "end": {
+          "line": 10,
+          "column": 4,
+          "offset": 312
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Tildes in info strings are fine after tilde fences:",
+          "position": {
+            "start": {
+              "line": 12,
+              "column": 1,
+              "offset": 314
+            },
+            "end": {
+              "line": 12,
+              "column": 52,
+              "offset": 365
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 12,
+          "column": 1,
+          "offset": 314
+        },
+        "end": {
+          "line": 12,
+          "column": 52,
+          "offset": 365
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "~~~js filename=~/.bashrc\nconsole.log(1)\n~~~",
+          "position": {
+            "start": {
+              "line": 14,
+              "column": 1,
+              "offset": 367
+            },
+            "end": {
+              "line": 16,
+              "column": 4,
+              "offset": 410
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 14,
+          "column": 1,
+          "offset": 367
+        },
+        "end": {
+          "line": 16,
+          "column": 4,
+          "offset": 410
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Backticks in info strings are fine after tilde fences:",
+          "position": {
+            "start": {
+              "line": 18,
+              "column": 1,
+              "offset": 412
+            },
+            "end": {
+              "line": 18,
+              "column": 55,
+              "offset": 466
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 18,
+          "column": 1,
+          "offset": 412
+        },
+        "end": {
+          "line": 18,
+          "column": 55,
+          "offset": 466
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "~~~js title=",
+          "position": {
+            "start": {
+              "line": 20,
+              "column": 1,
+              "offset": 468
+            },
+            "end": {
+              "line": 20,
+              "column": 13,
+              "offset": 480
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": ".bashrc",
+          "position": {
+            "start": {
+              "line": 20,
+              "column": 13,
+              "offset": 480
+            },
+            "end": {
+              "line": 20,
+              "column": 22,
+              "offset": 489
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "\nconsole.log(1)\n~~~",
+          "position": {
+            "start": {
+              "line": 20,
+              "column": 22,
+              "offset": 489
+            },
+            "end": {
+              "line": 22,
+              "column": 4,
+              "offset": 508
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 20,
+          "column": 1,
+          "offset": 468
+        },
+        "end": {
+          "line": 22,
+          "column": 4,
+          "offset": 508
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Backticks in info strings are ",
+          "position": {
+            "start": {
+              "line": 24,
+              "column": 1,
+              "offset": 510
+            },
+            "end": {
+              "line": 24,
+              "column": 31,
+              "offset": 540
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "strong",
+          "children": [
+            {
+              "type": "text",
+              "value": "not",
+              "position": {
+                "start": {
+                  "line": 24,
+                  "column": 33,
+                  "offset": 542
+                },
+                "end": {
+                  "line": 24,
+                  "column": 36,
+                  "offset": 545
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 24,
+              "column": 31,
+              "offset": 540
+            },
+            "end": {
+              "line": 24,
+              "column": 38,
+              "offset": 547
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " fine after backtick fences:",
+          "position": {
+            "start": {
+              "line": 24,
+              "column": 38,
+              "offset": 547
+            },
+            "end": {
+              "line": 24,
+              "column": 66,
+              "offset": 575
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 24,
+          "column": 1,
+          "offset": 510
+        },
+        "end": {
+          "line": 24,
+          "column": 66,
+          "offset": 575
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "inlineCode",
+          "value": "js title=`.bashrc`\nconsole.log(1)",
+          "position": {
+            "start": {
+              "line": 26,
+              "column": 1,
+              "offset": 577
+            },
+            "end": {
+              "line": 28,
+              "column": 4,
+              "offset": 617
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 26,
+          "column": 1,
+          "offset": 577
+        },
+        "end": {
+          "line": 28,
+          "column": 4,
+          "offset": 617
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 29,
+      "column": 1,
+      "offset": 618
+    }
+  }
+}


### PR DESCRIPTION
Related to mdx-js/mdx#630.
Closes GH-421.

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/master/support.md
https://github.com/remarkjs/.github/blob/master/contributing.md
-->
