### PR TITLE
Don't escape an exclamation mark unnecessarily.

### DIFF
--- a/packages/remark-stringify/lib/escape.js
+++ b/packages/remark-stringify/lib/escape.js
@@ -90,8 +90,6 @@ function factory(options) {
         character === backslash ||
         character === graveAccent ||
         character === asterisk ||
-        (character === exclamationMark &&
-          value.charAt(position + 1) === leftSquareBracket) ||
         character === leftSquareBracket ||
         character === lessThan ||
         (character === ampersand && prefix(value.slice(position)) > 0) ||

--- a/packages/remark-stringify/test.js
+++ b/packages/remark-stringify/test.js
@@ -871,7 +871,7 @@ test('stringify escapes', function(t) {
 
   t.equal(toString(u('image', {alt: 'a]b'})), '![a\\]b](<>)', '`]` (in images)')
 
-  t.equal(toString('![a'), '\\!\\[a', '`!` before `[`')
+  t.equal(toString('![a'), '!\\[a', '`!` before `[`')
 
   t.equal(toString('a~b'), 'a~b', '`~`')
   t.equal(toString('a~~b'), 'a\\~~b', '`~~`')


### PR DESCRIPTION
Hi 

With that commit an exclamation mark will not be always escaped before a
square bracket.
It will be only before link.

Closes GH-427.

That PR doesn't change the facts that:

- Exclamation mark still unnecessarily escaped before auto-link (`!<http://a.link.org>` => `\\!<http://a.link.org>`. 
- Exclamation marks still not escaped before footnotes. I don't think they should be.

💕