### PR TITLE
Fix broken GitHub's help article links

### DIFF
--- a/packages/remark-parse/readme.md
+++ b/packages/remark-parse/readme.md
@@ -119,11 +119,11 @@ hello ~~hi~~ world
 
 Turns on:
 
-*   [Fenced code blocks](https://help.github.com/articles/github-flavored-markdown/#fenced-code-blocks)
-*   [Autolinking of URLs](https://help.github.com/articles/github-flavored-markdown/#url-autolinking)
-*   [Deletions (strikethrough)](https://help.github.com/articles/github-flavored-markdown/#strikethrough)
-*   [Task lists](https://help.github.com/articles/writing-on-github/#task-lists)
-*   [Tables](https://help.github.com/articles/github-flavored-markdown/#tables)
+*   [Fenced code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks#fenced-code-blocks)
+*   [Autolinking of URLs](https://help.github.com/articles/autolinked-references-and-urls)
+*   [Deletions (strikethrough)](https://help.github.com/articles/basic-writing-and-formatting-syntax#styling-text)
+*   [Task lists](https://help.github.com/articles/basic-writing-and-formatting-syntax#task-lists)
+*   [Tables](https://help.github.com/articles/organizing-information-with-tables)
 
 ###### `options.commonmark`
 


### PR DESCRIPTION
Those URLs were changed during the redesign of the help center.

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/master/support.md
https://github.com/remarkjs/.github/blob/master/contributing.md
-->
