### PR TITLE
types: export remark options type

### DIFF
--- a/packages/remark/types/index.d.ts
+++ b/packages/remark/types/index.d.ts
@@ -4,11 +4,13 @@ import unified = require('unified')
 import remarkParse = require('remark-parse')
 import remarkStringify = require('remark-stringify')
 
-type RemarkOptions = remarkParse.RemarkParseOptions &
-  remarkStringify.RemarkStringifyOptions
+declare namespace remark {
+  type RemarkOptions = remarkParse.RemarkParseOptions &
+    remarkStringify.RemarkStringifyOptions
+}
 
 declare function remark<
-  P extends Partial<RemarkOptions> = Partial<RemarkOptions>
+  P extends Partial<remark.RemarkOptions> = Partial<remark.RemarkOptions>
 >(): unified.Processor<P>
 
 export = remark


### PR DESCRIPTION
This was intended to be exported before but got missed.
It allows downstream adopters to reuse the full options type.
