### PR TITLE
Stop appending linefeeds on consecutive runs

### DIFF
--- a/packages/remark-stringify/lib/visitors/root.js
+++ b/packages/remark-stringify/lib/visitors/root.js
@@ -7,5 +7,9 @@ var lineFeed = '\n'
 // Stringify a root.
 // Adds a final newline to ensure valid POSIX files. */
 function root(node) {
-  return this.block(node) + lineFeed
+  var block = this.block(node)
+  if (block.substr(lineFeed.length * -1) === lineFeed) {
+    return block
+  }
+  return block + lineFeed
 }

--- a/packages/remark/test.js
+++ b/packages/remark/test.js
@@ -33,6 +33,14 @@ test('remark().processSync(value)', function(t) {
     'should accept stringify options'
   )
 
+  t.equal(
+    remark()
+      .processSync('<!-- last line\n')
+      .toString(),
+    '<!-- last line\n',
+    'should not add more than one linefeed at the end'
+  )
+
   t.throws(
     function() {
       remark()


### PR DESCRIPTION
If I run `remark-cli` several times on a file, each run will insert a final newline to the end of the checked target file.

This commit adds a verification to check if the file already ends with a linefeed and doesn't include additional ones when not needed.