### PR TITLE
Fix dead link to unified homepage

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -60,7 +60,7 @@
     remark is a Markdown processor powered by
     <a href=https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins>plugins</a>
     part of the
-    <a href=https://unified.js.org>unified</a>
+    <a href=https://unifiedjs.com>unified</a>
     collective.
     The project
     <a href=https://github.com/remarkjs/remark/tree/master/packages/remark-parse#readme>parses</a>
@@ -248,7 +248,7 @@ process.stdin.pipe(stream(processor)).pipe(process.stdout)
   <p>
     View the unified project on
     <a href=https://github.com/unifiedjs/unified>GitHub</a> or peruse
-    the <a href=https://unified.js.org>website</a>.
+    the <a href=https://unifiedjs.com>website</a>.
   </p>
 </article>
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/master/support.md
https://github.com/remarkjs/.github/blob/master/contributing.md
-->
The link to https://unified.js.org is dead and it appears to have moved to https://unifiedjs.com according to https://github.com/unifiedjs/unified.