### PR TITLE
Add partial interface exports

### DIFF
--- a/packages/remark-parse/types/index.d.ts
+++ b/packages/remark-parse/types/index.d.ts
@@ -13,8 +13,8 @@ declare class RemarkParser implements Parser {
 }
 
 declare namespace remarkParse {
-  interface Parse extends Plugin<[Partial<RemarkParseOptions>?]> {
-    (options: Partial<RemarkParseOptions>): void
+  interface Parse extends Plugin<[PartialRemarkParseOptions?]> {
+    (options: PartialRemarkParseOptions): void
     Parser: typeof RemarkParser
   }
 
@@ -27,6 +27,8 @@ declare namespace remarkParse {
     blocks: string[]
     pedantic: boolean
   }
+
+  type PartialRemarkParseOptions = Partial<RemarkParseOptions>
 
   interface Add {
     (node: Node, parent?: Parent): Node

--- a/packages/remark-parse/types/test.ts
+++ b/packages/remark-parse/types/test.ts
@@ -1,13 +1,13 @@
 import unified = require('unified')
 import remarkParse = require('remark-parse')
 
-const parseOptions = {
+const partialParseOptions: remarkParse.PartialRemarkParseOptions = {
   gfm: true,
   pedantic: true
 }
 
 unified().use(remarkParse)
-unified().use(remarkParse, parseOptions)
+unified().use(remarkParse, partialParseOptions)
 
 const badParseOptions = {
   gfm: 'true'
@@ -15,3 +15,14 @@ const badParseOptions = {
 
 // $ExpectError
 unified().use(remarkParse, badParseOptions)
+
+// $ExpectError
+const parseOptions: remarkParse.RemarkParseOptions = {
+  gfm: true,
+  pedantic: true
+}
+
+const badParseOptionsInterface: remarkParse.PartialRemarkParseOptions = {
+  // $ExpectError
+  gfm: 'true'
+}

--- a/packages/remark-stringify/types/index.d.ts
+++ b/packages/remark-stringify/types/index.d.ts
@@ -11,9 +11,9 @@ declare class RemarkCompiler implements Compiler {
 }
 
 declare namespace remarkStringify {
-  interface Stringify extends Plugin<[Partial<RemarkStringifyOptions>?]> {
+  interface Stringify extends Plugin<[PartialRemarkStringifyOptions?]> {
     Compiler: typeof RemarkCompiler
-    (this: Processor, options?: Partial<RemarkStringifyOptions>): void
+    (this: Processor, options?: PartialRemarkStringifyOptions): void
   }
 
   type Compiler = RemarkCompiler
@@ -39,6 +39,8 @@ declare namespace remarkStringify {
     strong: '_' | '*'
     emphasis: '_' | '*'
   }
+
+  type PartialRemarkStringifyOptions = Partial<RemarkStringifyOptions>
 
   type Visitor = (node: Node, parent?: Parent) => string
 }

--- a/packages/remark-stringify/types/test.ts
+++ b/packages/remark-stringify/types/test.ts
@@ -1,5 +1,6 @@
 import remarkStringify = require('remark-stringify')
 import unified = require('unified')
+
 import {Node, Parent} from 'unist'
 
 const inferredStringifyOptions = {
@@ -12,7 +13,7 @@ unified().use(remarkStringify)
 unified().use(remarkStringify, inferredStringifyOptions)
 
 // These cannot be automatically inferred by TypeScript
-const nonInferredStringifyOptions: Partial<remarkStringify.RemarkStringifyOptions> = {
+const nonInferredStringifyOptions: remarkStringify.PartialRemarkStringifyOptions = {
   fence: '~',
   bullet: '+',
   listItemIndent: 'tab',
@@ -48,3 +49,15 @@ function gap(this: unified.Processor) {
 }
 
 const plugin: unified.Plugin = gap
+
+const badPartialStringifyOptions: remarkStringify.PartialRemarkStringifyOptions = {
+  // $ExpectError
+  gfm: 'true'
+}
+
+// $ExpectError
+const incompleteStringifyOptions: remarkStringify.RemarkStringifyOptions = {
+  gfm: true,
+  fences: true,
+  incrementListMarker: false
+}

--- a/packages/remark/types/index.d.ts
+++ b/packages/remark/types/index.d.ts
@@ -7,10 +7,11 @@ import remarkStringify = require('remark-stringify')
 declare namespace remark {
   type RemarkOptions = remarkParse.RemarkParseOptions &
     remarkStringify.RemarkStringifyOptions
+
+  type PartialRemarkOptions = remarkParse.PartialRemarkParseOptions &
+    remarkStringify.PartialRemarkStringifyOptions
 }
 
-declare function remark<
-  P extends Partial<remark.RemarkOptions> = Partial<remark.RemarkOptions>
->(): unified.Processor<P>
+declare function remark(): unified.Processor<remark.PartialRemarkOptions>
 
 export = remark

--- a/packages/remark/types/test.ts
+++ b/packages/remark/types/test.ts
@@ -13,3 +13,14 @@ remark().use({settings: {commonmark: true}})
 remark().use({settings: {doesNotExist: true}})
 // $ExpectError
 remark().use(plugin, {doesNotExist: 'true'})
+
+// $ExpectError
+const parseOptions: remark.RemarkOptions = {
+  gfm: true,
+  pedantic: true
+}
+
+const badParseOptionsInterface: remark.PartialRemarkOptions = {
+  // $ExpectError
+  gfm: 'true'
+}


### PR DESCRIPTION
With this an export for partial interfaces of option parameters is added.
These can be used in projects depending on remark to type their option parameters.
Fixes #452 

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/master/support.md
https://github.com/remarkjs/.github/blob/master/contributing.md
-->
