### PR TITLE
Add `remark-truncate-links` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -195,6 +195,8 @@ See [Creating plugins][create] below.
     — highlight code blocks in Markdown files using
     [Tree-sitter](https://tree-sitter.github.io/tree-sitter/)
     (rehype compatible)
+*   [`remark-truncate-links`](https://github.com/GaiAma/Coding4GaiAma/tree/master/packages/remark-truncate-links)
+    — truncate/shorten urls not manually named
 *   [`remark-unlink`](https://github.com/remarkjs/remark-unlink)
     — remove all links, references, and definitions
 *   [`remark-unwrap-images`](https://github.com/remarkjs/remark-unwrap-images)


### PR DESCRIPTION
Add [remark-truncate-links](https://github.com/GaiAma/Coding4GaiAma/tree/master/packages/remark-truncate-links)

shortens plain links in markdown not wrapped in `[]()`

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/master/support.md
https://github.com/remarkjs/.github/blob/master/contributing.md
-->
