### PR TITLE
remark-parse: fix parsing error on space after linefeed in footnote definition

### DIFF
--- a/packages/remark-parse/lib/tokenize/footnote-definition.js
+++ b/packages/remark-parse/lib/tokenize/footnote-definition.js
@@ -135,6 +135,10 @@ function footnoteDefinition(eat, value, silent) {
       queue += subqueue
       subqueue = ''
 
+      if (queue === lineFeed) {
+        break
+      }
+
       while (index < length) {
         character = value.charAt(index)
 

--- a/packages/remark/test.js
+++ b/packages/remark/test.js
@@ -43,5 +43,11 @@ test('remark().processSync(value)', function(t) {
     'should throw when `pedantic` is `true`, `listItemIndent` is not `tab`, and compiling code in a list-item'
   )
 
+  t.doesNotThrow(function() {
+    remark()
+      .use({settings: {commonmark: true, footnotes: true}})
+      .parse('[^1]: Footnote with trailing newline and space\n ')
+  })
+
   t.end()
 })

--- a/packages/remark/test.js
+++ b/packages/remark/test.js
@@ -44,7 +44,7 @@ test('remark().processSync(value)', function(t) {
   )
 
   t.doesNotThrow(function() {
-    remark()
+    remark() // 1
       .use({settings: {commonmark: true, footnotes: true}})
       .parse('[^1]: Footnote with trailing newline and space\n ')
   })

--- a/test/fixtures/input/footnote-trailing-whitespace.text
+++ b/test/fixtures/input/footnote-trailing-whitespace.text
@@ -1,0 +1,1 @@
+[^1]: Footnote with trailing newline and space\n 

--- a/test/fixtures/input/footnote-trailing-whitespace.text
+++ b/test/fixtures/input/footnote-trailing-whitespace.text
@@ -1,1 +1,2 @@
-[^1]: Footnote with trailing newline and space\n 
+[^1]: Footnote with trailing newline and space
+ 

--- a/test/fixtures/tree/footnote-trailing-whitespace.footnotes.json
+++ b/test/fixtures/tree/footnote-trailing-whitespace.footnotes.json
@@ -1,0 +1,72 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "footnoteDefinition",
+      "identifier": "1",
+      "label": "1",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Footnote with trailing newline and space",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 7,
+                  "offset": 6
+                },
+                "end": {
+                  "line": 1,
+                  "column": 47,
+                  "offset": 46
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 7,
+              "offset": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 47,
+              "offset": 46
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 47,
+          "offset": 46
+        },
+        "indent": []
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1,
+      "offset": 49
+    }
+  }
+}

--- a/test/fixtures/tree/footnote-trailing-whitespace.json
+++ b/test/fixtures/tree/footnote-trailing-whitespace.json
@@ -1,0 +1,90 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "linkReference",
+          "identifier": "^1",
+          "label": "^1",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "^1",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 2,
+                  "offset": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 4,
+                  "offset": 3
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 5,
+              "offset": 4
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ": Footnote with trailing newline and space\\n ",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 5,
+              "offset": 4
+            },
+            "end": {
+              "line": 1,
+              "column": 50,
+              "offset": 49
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 50,
+          "offset": 49
+        },
+        "indent": []
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 1,
+      "offset": 50
+    }
+  }
+}

--- a/test/fixtures/tree/footnote-trailing-whitespace.json
+++ b/test/fixtures/tree/footnote-trailing-whitespace.json
@@ -44,7 +44,7 @@
         },
         {
           "type": "text",
-          "value": ": Footnote with trailing newline and space\\n ",
+          "value": ": Footnote with trailing newline and space",
           "position": {
             "start": {
               "line": 1,
@@ -53,8 +53,8 @@
             },
             "end": {
               "line": 1,
-              "column": 50,
-              "offset": 49
+              "column": 47,
+              "offset": 46
             },
             "indent": []
           }
@@ -68,8 +68,8 @@
         },
         "end": {
           "line": 1,
-          "column": 50,
-          "offset": 49
+          "column": 47,
+          "offset": 46
         },
         "indent": []
       }
@@ -82,9 +82,9 @@
       "offset": 0
     },
     "end": {
-      "line": 2,
+      "line": 3,
       "column": 1,
-      "offset": 50
+      "offset": 49
     }
   }
 }


### PR DESCRIPTION
Fixes #468 

If I'm correct, space isn't allowed after linefeed in footnote definition.