### PR TITLE
Add deprecation note for `pedantic` mode

### DIFF
--- a/packages/remark-parse/readme.md
+++ b/packages/remark-parse/readme.md
@@ -175,20 +175,10 @@ referenced from inside other footnotes.
 
 ###### `options.pedantic`
 
-Pedantic mode (`boolean`, default: `false`).
-
-```markdown
-Check out some_file_name.txt
-```
-
-Turns on:
-
-*   Emphasis (`_alpha_`) and importance (`__bravo__`) with underscores in words
-*   Unordered lists with different markers (`*`, `-`, `+`)
-*   If `commonmark` is also turned on, ordered lists with different markers
-    (`.`, `)`)
-*   And removes less spaces in list items (at most four, instead of the whole
-    indent)
+⚠️ Pedantic was previously used to mimic old-style Markdown mode: no tables, no
+fenced code, and with many bugs.
+It’s currently still “working”, but please do not use it, it’ll be removed in
+the future.
 
 ###### `options.blocks`
 

--- a/packages/remark-stringify/readme.md
+++ b/packages/remark-stringify/readme.md
@@ -124,9 +124,10 @@ Stringify for CommonMark compatible Markdown (`boolean`, default: `false`).
 
 ###### `options.pedantic`
 
-Stringify for pedantic compatible markdown (`boolean`, default: `false`).
-
-*   Escape underscores in words
+⚠️ Pedantic was previously used to mimic old-style Markdown mode: no tables, no
+fenced code, and with many bugs.
+It’s currently still “working”, but please do not use it, it’ll be removed in
+the future.
 
 ###### `options.entities`
 


### PR DESCRIPTION
Closes GH-470.

pedantic mode is buggy. It won’t be in micromark. This PR warns users not to use it.