### PR TITLE
Fixes lists with mixed indentation

### DIFF
--- a/packages/remark-parse/lib/util/get-indentation.js
+++ b/packages/remark-parse/lib/util/get-indentation.js
@@ -15,6 +15,7 @@ function indentation(value) {
   var character = value.charAt(index)
   var stops = {}
   var size
+  var lastIndent = 0
 
   while (character === tab || character === space) {
     size = character === tab ? tabSize : spaceSize
@@ -25,7 +26,10 @@ function indentation(value) {
       indent = Math.floor(indent / size) * size
     }
 
-    stops[indent] = index
+    while (lastIndent < indent) {
+      stops[++lastIndent] = index
+    }
+
     character = value.charAt(++index)
   }
 

--- a/packages/remark-parse/lib/util/remove-indentation.js
+++ b/packages/remark-parse/lib/util/remove-indentation.js
@@ -6,7 +6,6 @@ var getIndent = require('./get-indentation')
 
 module.exports = indentation
 
-var tab = '\t'
 var lineFeed = '\n'
 var space = ' '
 var exclamationMark = '!'
@@ -21,7 +20,6 @@ function indentation(value, maximum) {
   var index
   var indentation
   var stops
-  var padding
 
   values.unshift(repeat(space, maximum) + exclamationMark)
 
@@ -56,18 +54,7 @@ function indentation(value, maximum) {
         index--
       }
 
-      if (
-        trim(values[position]).length !== 0 &&
-        minIndent &&
-        index !== minIndent
-      ) {
-        padding = tab
-      } else {
-        padding = ''
-      }
-
-      values[position] =
-        padding + values[position].slice(index in stops ? stops[index] + 1 : 0)
+      values[position] = values[position].slice(stops[index] + 1)
     }
   }
 

--- a/test/fixtures/input/list-mixed-indentation.text
+++ b/test/fixtures/input/list-mixed-indentation.text
@@ -1,0 +1,34 @@
+# Mixed spaces and tabs
+
+- (item 1.) Minimum list, equivalent to two spaces
+ - (item 2.) indented with 1 space, not enough indentation to be a subitem
+	- (item 2.1.) indented with tab
+
+
+- (item 1.) Minimum list, equivalent to two spaces
+  - (item 1.1.) indentend with 2 spaces
+	- (item 1.2.) indented with tab
+
+
+-  (item 1.) List with 1 extra space
+   - (item 1.1.) indentend with 3 spaces
+	- (item 1.2.) indented with tab
+
+
+-   (item 1.) List with 2 extra space, equivalent to 1 tab indentation
+    - (item 1.1.) indentend with 4 spaces
+	- (item 1.2.) indented with tab
+
+
+-	(item 1.) List with 1 tab, equivalent to 4 spaces
+    - (item 1.1.) indentend with 4 spaces
+	- (item 1.2.) indented with tab
+
+
+-	(item 1.) list with double indentation and mixed items
+	- (item 1.1.) normal indentation with 1 tab
+        - (item 1.1.1.) item with 4 spaces + 4 spaces
+	    - (item 1.1.2.) item with tab + 4 spaces
+    	- (item 1.1.3.) item with 4 spaces + tab
+		- (item 1.1.4.) item with tab + tab
+  	  - (item 1.1.5.) item with 2 spaces + tab + 2 spaces (nasty!)

--- a/test/fixtures/tree/list-mixed-indentation.commonmark.json
+++ b/test/fixtures/tree/list-mixed-indentation.commonmark.json
@@ -1,0 +1,1514 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "Mixed spaces and tabs",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 3,
+              "offset": 2
+            },
+            "end": {
+              "line": 1,
+              "column": 24,
+              "offset": 23
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 24,
+          "offset": 23
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "spread": true,
+      "children": [
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) Minimum list, equivalent to two spaces",
+                  "position": {
+                    "start": {
+                      "line": 3,
+                      "column": 3,
+                      "offset": 27
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 51,
+                      "offset": 75
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 3,
+                  "offset": 27
+                },
+                "end": {
+                  "line": 3,
+                  "column": 51,
+                  "offset": 75
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 1,
+              "offset": 25
+            },
+            "end": {
+              "line": 3,
+              "column": 51,
+              "offset": 75
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 2.) indented with 1 space, not enough indentation to be a subitem",
+                  "position": {
+                    "start": {
+                      "line": 4,
+                      "column": 4,
+                      "offset": 79
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 75,
+                      "offset": 150
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 4,
+                  "column": 4,
+                  "offset": 79
+                },
+                "end": {
+                  "line": 4,
+                  "column": 75,
+                  "offset": 150
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 2.1.) indented with tab",
+                          "position": {
+                            "start": {
+                              "line": 5,
+                              "column": 4,
+                              "offset": 154
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 33,
+                              "offset": 183
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 5,
+                          "column": 4,
+                          "offset": 154
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 33,
+                          "offset": 183
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 5,
+                      "column": 2,
+                      "offset": 152
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 33,
+                      "offset": 183
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 5,
+                  "column": 2,
+                  "offset": 152
+                },
+                "end": {
+                  "line": 5,
+                  "column": 33,
+                  "offset": 183
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 4,
+              "column": 1,
+              "offset": 76
+            },
+            "end": {
+              "line": 6,
+              "column": 1,
+              "offset": 184
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        },
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) Minimum list, equivalent to two spaces",
+                  "position": {
+                    "start": {
+                      "line": 8,
+                      "column": 3,
+                      "offset": 188
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 51,
+                      "offset": 236
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 8,
+                  "column": 3,
+                  "offset": 188
+                },
+                "end": {
+                  "line": 8,
+                  "column": 51,
+                  "offset": 236
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.1.) indentend with 2 spaces",
+                          "position": {
+                            "start": {
+                              "line": 9,
+                              "column": 5,
+                              "offset": 241
+                            },
+                            "end": {
+                              "line": 9,
+                              "column": 40,
+                              "offset": 276
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 9,
+                          "column": 5,
+                          "offset": 241
+                        },
+                        "end": {
+                          "line": 9,
+                          "column": 40,
+                          "offset": 276
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 9,
+                      "column": 3,
+                      "offset": 239
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 40,
+                      "offset": 276
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.2.) indented with tab",
+                          "position": {
+                            "start": {
+                              "line": 10,
+                              "column": 4,
+                              "offset": 280
+                            },
+                            "end": {
+                              "line": 10,
+                              "column": 33,
+                              "offset": 309
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 10,
+                          "column": 4,
+                          "offset": 280
+                        },
+                        "end": {
+                          "line": 10,
+                          "column": 33,
+                          "offset": 309
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 10,
+                      "column": 2,
+                      "offset": 278
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 33,
+                      "offset": 309
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 3,
+                  "offset": 239
+                },
+                "end": {
+                  "line": 10,
+                  "column": 33,
+                  "offset": 309
+                },
+                "indent": [
+                  2
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 8,
+              "column": 1,
+              "offset": 186
+            },
+            "end": {
+              "line": 11,
+              "column": 1,
+              "offset": 310
+            },
+            "indent": [
+              1,
+              1,
+              1
+            ]
+          }
+        },
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) List with 1 extra space",
+                  "position": {
+                    "start": {
+                      "line": 13,
+                      "column": 4,
+                      "offset": 315
+                    },
+                    "end": {
+                      "line": 13,
+                      "column": 37,
+                      "offset": 348
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 13,
+                  "column": 4,
+                  "offset": 315
+                },
+                "end": {
+                  "line": 13,
+                  "column": 37,
+                  "offset": 348
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.1.) indentend with 3 spaces",
+                          "position": {
+                            "start": {
+                              "line": 14,
+                              "column": 6,
+                              "offset": 354
+                            },
+                            "end": {
+                              "line": 14,
+                              "column": 41,
+                              "offset": 389
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 14,
+                          "column": 6,
+                          "offset": 354
+                        },
+                        "end": {
+                          "line": 14,
+                          "column": 41,
+                          "offset": 389
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 14,
+                      "column": 4,
+                      "offset": 352
+                    },
+                    "end": {
+                      "line": 14,
+                      "column": 41,
+                      "offset": 389
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.2.) indented with tab",
+                          "position": {
+                            "start": {
+                              "line": 15,
+                              "column": 4,
+                              "offset": 393
+                            },
+                            "end": {
+                              "line": 15,
+                              "column": 33,
+                              "offset": 422
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 15,
+                          "column": 4,
+                          "offset": 393
+                        },
+                        "end": {
+                          "line": 15,
+                          "column": 33,
+                          "offset": 422
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 15,
+                      "column": 2,
+                      "offset": 391
+                    },
+                    "end": {
+                      "line": 15,
+                      "column": 33,
+                      "offset": 422
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 14,
+                  "column": 4,
+                  "offset": 352
+                },
+                "end": {
+                  "line": 15,
+                  "column": 33,
+                  "offset": 422
+                },
+                "indent": [
+                  2
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 13,
+              "column": 1,
+              "offset": 312
+            },
+            "end": {
+              "line": 16,
+              "column": 1,
+              "offset": 423
+            },
+            "indent": [
+              1,
+              1,
+              1
+            ]
+          }
+        },
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) List with 2 extra space, equivalent to 1 tab indentation",
+                  "position": {
+                    "start": {
+                      "line": 18,
+                      "column": 5,
+                      "offset": 429
+                    },
+                    "end": {
+                      "line": 18,
+                      "column": 71,
+                      "offset": 495
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 18,
+                  "column": 5,
+                  "offset": 429
+                },
+                "end": {
+                  "line": 18,
+                  "column": 71,
+                  "offset": 495
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.1.) indentend with 4 spaces",
+                          "position": {
+                            "start": {
+                              "line": 19,
+                              "column": 7,
+                              "offset": 502
+                            },
+                            "end": {
+                              "line": 19,
+                              "column": 42,
+                              "offset": 537
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 19,
+                          "column": 7,
+                          "offset": 502
+                        },
+                        "end": {
+                          "line": 19,
+                          "column": 42,
+                          "offset": 537
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 19,
+                      "column": 5,
+                      "offset": 500
+                    },
+                    "end": {
+                      "line": 19,
+                      "column": 42,
+                      "offset": 537
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.2.) indented with tab",
+                          "position": {
+                            "start": {
+                              "line": 20,
+                              "column": 4,
+                              "offset": 541
+                            },
+                            "end": {
+                              "line": 20,
+                              "column": 33,
+                              "offset": 570
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 20,
+                          "column": 4,
+                          "offset": 541
+                        },
+                        "end": {
+                          "line": 20,
+                          "column": 33,
+                          "offset": 570
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 20,
+                      "column": 2,
+                      "offset": 539
+                    },
+                    "end": {
+                      "line": 20,
+                      "column": 33,
+                      "offset": 570
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 19,
+                  "column": 5,
+                  "offset": 500
+                },
+                "end": {
+                  "line": 20,
+                  "column": 33,
+                  "offset": 570
+                },
+                "indent": [
+                  2
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 18,
+              "column": 1,
+              "offset": 425
+            },
+            "end": {
+              "line": 21,
+              "column": 1,
+              "offset": 571
+            },
+            "indent": [
+              1,
+              1,
+              1
+            ]
+          }
+        },
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) List with 1 tab, equivalent to 4 spaces",
+                  "position": {
+                    "start": {
+                      "line": 23,
+                      "column": 3,
+                      "offset": 575
+                    },
+                    "end": {
+                      "line": 23,
+                      "column": 52,
+                      "offset": 624
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 23,
+                  "column": 3,
+                  "offset": 575
+                },
+                "end": {
+                  "line": 23,
+                  "column": 52,
+                  "offset": 624
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.1.) indentend with 4 spaces",
+                          "position": {
+                            "start": {
+                              "line": 24,
+                              "column": 7,
+                              "offset": 631
+                            },
+                            "end": {
+                              "line": 24,
+                              "column": 42,
+                              "offset": 666
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 24,
+                          "column": 7,
+                          "offset": 631
+                        },
+                        "end": {
+                          "line": 24,
+                          "column": 42,
+                          "offset": 666
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 24,
+                      "column": 5,
+                      "offset": 629
+                    },
+                    "end": {
+                      "line": 24,
+                      "column": 42,
+                      "offset": 666
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.2.) indented with tab",
+                          "position": {
+                            "start": {
+                              "line": 25,
+                              "column": 4,
+                              "offset": 670
+                            },
+                            "end": {
+                              "line": 25,
+                              "column": 33,
+                              "offset": 699
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 25,
+                          "column": 4,
+                          "offset": 670
+                        },
+                        "end": {
+                          "line": 25,
+                          "column": 33,
+                          "offset": 699
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 25,
+                      "column": 2,
+                      "offset": 668
+                    },
+                    "end": {
+                      "line": 25,
+                      "column": 33,
+                      "offset": 699
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 24,
+                  "column": 5,
+                  "offset": 629
+                },
+                "end": {
+                  "line": 25,
+                  "column": 33,
+                  "offset": 699
+                },
+                "indent": [
+                  2
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 23,
+              "column": 1,
+              "offset": 573
+            },
+            "end": {
+              "line": 26,
+              "column": 1,
+              "offset": 700
+            },
+            "indent": [
+              1,
+              1,
+              1
+            ]
+          }
+        },
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) list with double indentation and mixed items",
+                  "position": {
+                    "start": {
+                      "line": 28,
+                      "column": 3,
+                      "offset": 704
+                    },
+                    "end": {
+                      "line": 28,
+                      "column": 57,
+                      "offset": 758
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 28,
+                  "column": 3,
+                  "offset": 704
+                },
+                "end": {
+                  "line": 28,
+                  "column": 57,
+                  "offset": 758
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.1.) normal indentation with 1 tab",
+                          "position": {
+                            "start": {
+                              "line": 29,
+                              "column": 4,
+                              "offset": 762
+                            },
+                            "end": {
+                              "line": 29,
+                              "column": 45,
+                              "offset": 803
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 29,
+                          "column": 4,
+                          "offset": 762
+                        },
+                        "end": {
+                          "line": 29,
+                          "column": 45,
+                          "offset": 803
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "list",
+                      "ordered": false,
+                      "start": null,
+                      "spread": false,
+                      "children": [
+                        {
+                          "type": "listItem",
+                          "spread": false,
+                          "checked": null,
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "(item 1.1.1.) item with 4 spaces + 4 spaces",
+                                  "position": {
+                                    "start": {
+                                      "line": 30,
+                                      "column": 11,
+                                      "offset": 814
+                                    },
+                                    "end": {
+                                      "line": 30,
+                                      "column": 54,
+                                      "offset": 857
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 30,
+                                  "column": 11,
+                                  "offset": 814
+                                },
+                                "end": {
+                                  "line": 30,
+                                  "column": 54,
+                                  "offset": 857
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 30,
+                              "column": 7,
+                              "offset": 810
+                            },
+                            "end": {
+                              "line": 30,
+                              "column": 54,
+                              "offset": 857
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "listItem",
+                          "spread": false,
+                          "checked": null,
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "(item 1.1.2.) item with tab + 4 spaces",
+                                  "position": {
+                                    "start": {
+                                      "line": 31,
+                                      "column": 8,
+                                      "offset": 865
+                                    },
+                                    "end": {
+                                      "line": 31,
+                                      "column": 46,
+                                      "offset": 903
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 31,
+                                  "column": 8,
+                                  "offset": 865
+                                },
+                                "end": {
+                                  "line": 31,
+                                  "column": 46,
+                                  "offset": 903
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 31,
+                              "column": 4,
+                              "offset": 861
+                            },
+                            "end": {
+                              "line": 31,
+                              "column": 46,
+                              "offset": 903
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "listItem",
+                          "spread": false,
+                          "checked": null,
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "(item 1.1.3.) item with 4 spaces + tab",
+                                  "position": {
+                                    "start": {
+                                      "line": 32,
+                                      "column": 8,
+                                      "offset": 911
+                                    },
+                                    "end": {
+                                      "line": 32,
+                                      "column": 46,
+                                      "offset": 949
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 32,
+                                  "column": 8,
+                                  "offset": 911
+                                },
+                                "end": {
+                                  "line": 32,
+                                  "column": 46,
+                                  "offset": 949
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 32,
+                              "column": 6,
+                              "offset": 909
+                            },
+                            "end": {
+                              "line": 32,
+                              "column": 46,
+                              "offset": 949
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "listItem",
+                          "spread": false,
+                          "checked": null,
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "(item 1.1.4.) item with tab + tab",
+                                  "position": {
+                                    "start": {
+                                      "line": 33,
+                                      "column": 5,
+                                      "offset": 954
+                                    },
+                                    "end": {
+                                      "line": 33,
+                                      "column": 38,
+                                      "offset": 987
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 33,
+                                  "column": 5,
+                                  "offset": 954
+                                },
+                                "end": {
+                                  "line": 33,
+                                  "column": 38,
+                                  "offset": 987
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 33,
+                              "column": 3,
+                              "offset": 952
+                            },
+                            "end": {
+                              "line": 33,
+                              "column": 38,
+                              "offset": 987
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "listItem",
+                          "spread": false,
+                          "checked": null,
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "(item 1.1.5.) item with 2 spaces + tab + 2 spaces (nasty!)",
+                                  "position": {
+                                    "start": {
+                                      "line": 34,
+                                      "column": 8,
+                                      "offset": 995
+                                    },
+                                    "end": {
+                                      "line": 34,
+                                      "column": 66,
+                                      "offset": 1053
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 34,
+                                  "column": 8,
+                                  "offset": 995
+                                },
+                                "end": {
+                                  "line": 34,
+                                  "column": 66,
+                                  "offset": 1053
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 34,
+                              "column": 6,
+                              "offset": 993
+                            },
+                            "end": {
+                              "line": 34,
+                              "column": 66,
+                              "offset": 1053
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 30,
+                          "column": 7,
+                          "offset": 810
+                        },
+                        "end": {
+                          "line": 34,
+                          "column": 66,
+                          "offset": 1053
+                        },
+                        "indent": [
+                          4,
+                          6,
+                          3,
+                          6
+                        ]
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 29,
+                      "column": 2,
+                      "offset": 760
+                    },
+                    "end": {
+                      "line": 34,
+                      "column": 66,
+                      "offset": 1053
+                    },
+                    "indent": [
+                      5,
+                      2,
+                      5,
+                      2,
+                      4
+                    ]
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 29,
+                  "column": 2,
+                  "offset": 760
+                },
+                "end": {
+                  "line": 34,
+                  "column": 66,
+                  "offset": 1053
+                },
+                "indent": [
+                  5,
+                  2,
+                  5,
+                  2,
+                  4
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 28,
+              "column": 1,
+              "offset": 702
+            },
+            "end": {
+              "line": 34,
+              "column": 66,
+              "offset": 1053
+            },
+            "indent": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 1,
+          "offset": 25
+        },
+        "end": {
+          "line": 34,
+          "column": 66,
+          "offset": 1053
+        },
+        "indent": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 35,
+      "column": 1,
+      "offset": 1054
+    }
+  }
+}

--- a/test/fixtures/tree/list-mixed-indentation.json
+++ b/test/fixtures/tree/list-mixed-indentation.json
@@ -1,0 +1,1604 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "Mixed spaces and tabs",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 3,
+              "offset": 2
+            },
+            "end": {
+              "line": 1,
+              "column": 24,
+              "offset": 23
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 24,
+          "offset": 23
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "spread": false,
+      "children": [
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) Minimum list, equivalent to two spaces",
+                  "position": {
+                    "start": {
+                      "line": 3,
+                      "column": 3,
+                      "offset": 27
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 51,
+                      "offset": 75
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 3,
+                  "offset": 27
+                },
+                "end": {
+                  "line": 3,
+                  "column": 51,
+                  "offset": 75
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 1,
+              "offset": 25
+            },
+            "end": {
+              "line": 3,
+              "column": 51,
+              "offset": 75
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 2.) indented with 1 space, not enough indentation to be a subitem",
+                  "position": {
+                    "start": {
+                      "line": 4,
+                      "column": 4,
+                      "offset": 79
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 75,
+                      "offset": 150
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 4,
+                  "column": 4,
+                  "offset": 79
+                },
+                "end": {
+                  "line": 4,
+                  "column": 75,
+                  "offset": 150
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 2.1.) indented with tab",
+                          "position": {
+                            "start": {
+                              "line": 5,
+                              "column": 4,
+                              "offset": 154
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 33,
+                              "offset": 183
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 5,
+                          "column": 4,
+                          "offset": 154
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 33,
+                          "offset": 183
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 5,
+                      "column": 2,
+                      "offset": 152
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 33,
+                      "offset": 183
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 5,
+                  "column": 2,
+                  "offset": 152
+                },
+                "end": {
+                  "line": 5,
+                  "column": 33,
+                  "offset": 183
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 4,
+              "column": 1,
+              "offset": 76
+            },
+            "end": {
+              "line": 5,
+              "column": 33,
+              "offset": 183
+            },
+            "indent": [
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 1,
+          "offset": 25
+        },
+        "end": {
+          "line": 5,
+          "column": 33,
+          "offset": 183
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "spread": false,
+      "children": [
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) Minimum list, equivalent to two spaces",
+                  "position": {
+                    "start": {
+                      "line": 8,
+                      "column": 3,
+                      "offset": 188
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 51,
+                      "offset": 236
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 8,
+                  "column": 3,
+                  "offset": 188
+                },
+                "end": {
+                  "line": 8,
+                  "column": 51,
+                  "offset": 236
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.1.) indentend with 2 spaces",
+                          "position": {
+                            "start": {
+                              "line": 9,
+                              "column": 5,
+                              "offset": 241
+                            },
+                            "end": {
+                              "line": 9,
+                              "column": 40,
+                              "offset": 276
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 9,
+                          "column": 5,
+                          "offset": 241
+                        },
+                        "end": {
+                          "line": 9,
+                          "column": 40,
+                          "offset": 276
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 9,
+                      "column": 3,
+                      "offset": 239
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 40,
+                      "offset": 276
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.2.) indented with tab",
+                          "position": {
+                            "start": {
+                              "line": 10,
+                              "column": 4,
+                              "offset": 280
+                            },
+                            "end": {
+                              "line": 10,
+                              "column": 33,
+                              "offset": 309
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 10,
+                          "column": 4,
+                          "offset": 280
+                        },
+                        "end": {
+                          "line": 10,
+                          "column": 33,
+                          "offset": 309
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 10,
+                      "column": 2,
+                      "offset": 278
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 33,
+                      "offset": 309
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 3,
+                  "offset": 239
+                },
+                "end": {
+                  "line": 10,
+                  "column": 33,
+                  "offset": 309
+                },
+                "indent": [
+                  2
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 8,
+              "column": 1,
+              "offset": 186
+            },
+            "end": {
+              "line": 10,
+              "column": 33,
+              "offset": 309
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 8,
+          "column": 1,
+          "offset": 186
+        },
+        "end": {
+          "line": 10,
+          "column": 33,
+          "offset": 309
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "spread": false,
+      "children": [
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) List with 1 extra space",
+                  "position": {
+                    "start": {
+                      "line": 13,
+                      "column": 4,
+                      "offset": 315
+                    },
+                    "end": {
+                      "line": 13,
+                      "column": 37,
+                      "offset": 348
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 13,
+                  "column": 4,
+                  "offset": 315
+                },
+                "end": {
+                  "line": 13,
+                  "column": 37,
+                  "offset": 348
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.1.) indentend with 3 spaces",
+                          "position": {
+                            "start": {
+                              "line": 14,
+                              "column": 6,
+                              "offset": 354
+                            },
+                            "end": {
+                              "line": 14,
+                              "column": 41,
+                              "offset": 389
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 14,
+                          "column": 6,
+                          "offset": 354
+                        },
+                        "end": {
+                          "line": 14,
+                          "column": 41,
+                          "offset": 389
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 14,
+                      "column": 4,
+                      "offset": 352
+                    },
+                    "end": {
+                      "line": 14,
+                      "column": 41,
+                      "offset": 389
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.2.) indented with tab",
+                          "position": {
+                            "start": {
+                              "line": 15,
+                              "column": 4,
+                              "offset": 393
+                            },
+                            "end": {
+                              "line": 15,
+                              "column": 33,
+                              "offset": 422
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 15,
+                          "column": 4,
+                          "offset": 393
+                        },
+                        "end": {
+                          "line": 15,
+                          "column": 33,
+                          "offset": 422
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 15,
+                      "column": 2,
+                      "offset": 391
+                    },
+                    "end": {
+                      "line": 15,
+                      "column": 33,
+                      "offset": 422
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 14,
+                  "column": 4,
+                  "offset": 352
+                },
+                "end": {
+                  "line": 15,
+                  "column": 33,
+                  "offset": 422
+                },
+                "indent": [
+                  2
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 13,
+              "column": 1,
+              "offset": 312
+            },
+            "end": {
+              "line": 15,
+              "column": 33,
+              "offset": 422
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 13,
+          "column": 1,
+          "offset": 312
+        },
+        "end": {
+          "line": 15,
+          "column": 33,
+          "offset": 422
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "spread": false,
+      "children": [
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) List with 2 extra space, equivalent to 1 tab indentation",
+                  "position": {
+                    "start": {
+                      "line": 18,
+                      "column": 5,
+                      "offset": 429
+                    },
+                    "end": {
+                      "line": 18,
+                      "column": 71,
+                      "offset": 495
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 18,
+                  "column": 5,
+                  "offset": 429
+                },
+                "end": {
+                  "line": 18,
+                  "column": 71,
+                  "offset": 495
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.1.) indentend with 4 spaces",
+                          "position": {
+                            "start": {
+                              "line": 19,
+                              "column": 7,
+                              "offset": 502
+                            },
+                            "end": {
+                              "line": 19,
+                              "column": 42,
+                              "offset": 537
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 19,
+                          "column": 7,
+                          "offset": 502
+                        },
+                        "end": {
+                          "line": 19,
+                          "column": 42,
+                          "offset": 537
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 19,
+                      "column": 5,
+                      "offset": 500
+                    },
+                    "end": {
+                      "line": 19,
+                      "column": 42,
+                      "offset": 537
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.2.) indented with tab",
+                          "position": {
+                            "start": {
+                              "line": 20,
+                              "column": 4,
+                              "offset": 541
+                            },
+                            "end": {
+                              "line": 20,
+                              "column": 33,
+                              "offset": 570
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 20,
+                          "column": 4,
+                          "offset": 541
+                        },
+                        "end": {
+                          "line": 20,
+                          "column": 33,
+                          "offset": 570
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 20,
+                      "column": 2,
+                      "offset": 539
+                    },
+                    "end": {
+                      "line": 20,
+                      "column": 33,
+                      "offset": 570
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 19,
+                  "column": 5,
+                  "offset": 500
+                },
+                "end": {
+                  "line": 20,
+                  "column": 33,
+                  "offset": 570
+                },
+                "indent": [
+                  2
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 18,
+              "column": 1,
+              "offset": 425
+            },
+            "end": {
+              "line": 20,
+              "column": 33,
+              "offset": 570
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 18,
+          "column": 1,
+          "offset": 425
+        },
+        "end": {
+          "line": 20,
+          "column": 33,
+          "offset": 570
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "spread": false,
+      "children": [
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) List with 1 tab, equivalent to 4 spaces",
+                  "position": {
+                    "start": {
+                      "line": 23,
+                      "column": 3,
+                      "offset": 575
+                    },
+                    "end": {
+                      "line": 23,
+                      "column": 52,
+                      "offset": 624
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 23,
+                  "column": 3,
+                  "offset": 575
+                },
+                "end": {
+                  "line": 23,
+                  "column": 52,
+                  "offset": 624
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.1.) indentend with 4 spaces",
+                          "position": {
+                            "start": {
+                              "line": 24,
+                              "column": 7,
+                              "offset": 631
+                            },
+                            "end": {
+                              "line": 24,
+                              "column": 42,
+                              "offset": 666
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 24,
+                          "column": 7,
+                          "offset": 631
+                        },
+                        "end": {
+                          "line": 24,
+                          "column": 42,
+                          "offset": 666
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 24,
+                      "column": 5,
+                      "offset": 629
+                    },
+                    "end": {
+                      "line": 24,
+                      "column": 42,
+                      "offset": 666
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.2.) indented with tab",
+                          "position": {
+                            "start": {
+                              "line": 25,
+                              "column": 4,
+                              "offset": 670
+                            },
+                            "end": {
+                              "line": 25,
+                              "column": 33,
+                              "offset": 699
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 25,
+                          "column": 4,
+                          "offset": 670
+                        },
+                        "end": {
+                          "line": 25,
+                          "column": 33,
+                          "offset": 699
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 25,
+                      "column": 2,
+                      "offset": 668
+                    },
+                    "end": {
+                      "line": 25,
+                      "column": 33,
+                      "offset": 699
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 24,
+                  "column": 5,
+                  "offset": 629
+                },
+                "end": {
+                  "line": 25,
+                  "column": 33,
+                  "offset": 699
+                },
+                "indent": [
+                  2
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 23,
+              "column": 1,
+              "offset": 573
+            },
+            "end": {
+              "line": 25,
+              "column": 33,
+              "offset": 699
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 23,
+          "column": 1,
+          "offset": 573
+        },
+        "end": {
+          "line": 25,
+          "column": 33,
+          "offset": 699
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "spread": false,
+      "children": [
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "(item 1.) list with double indentation and mixed items",
+                  "position": {
+                    "start": {
+                      "line": 28,
+                      "column": 3,
+                      "offset": 704
+                    },
+                    "end": {
+                      "line": 28,
+                      "column": 57,
+                      "offset": 758
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 28,
+                  "column": 3,
+                  "offset": 704
+                },
+                "end": {
+                  "line": 28,
+                  "column": 57,
+                  "offset": 758
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "spread": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "spread": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "(item 1.1.) normal indentation with 1 tab",
+                          "position": {
+                            "start": {
+                              "line": 29,
+                              "column": 4,
+                              "offset": 762
+                            },
+                            "end": {
+                              "line": 29,
+                              "column": 45,
+                              "offset": 803
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 29,
+                          "column": 4,
+                          "offset": 762
+                        },
+                        "end": {
+                          "line": 29,
+                          "column": 45,
+                          "offset": 803
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "list",
+                      "ordered": false,
+                      "start": null,
+                      "spread": false,
+                      "children": [
+                        {
+                          "type": "listItem",
+                          "spread": false,
+                          "checked": null,
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "(item 1.1.1.) item with 4 spaces + 4 spaces",
+                                  "position": {
+                                    "start": {
+                                      "line": 30,
+                                      "column": 11,
+                                      "offset": 814
+                                    },
+                                    "end": {
+                                      "line": 30,
+                                      "column": 54,
+                                      "offset": 857
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 30,
+                                  "column": 11,
+                                  "offset": 814
+                                },
+                                "end": {
+                                  "line": 30,
+                                  "column": 54,
+                                  "offset": 857
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 30,
+                              "column": 7,
+                              "offset": 810
+                            },
+                            "end": {
+                              "line": 30,
+                              "column": 54,
+                              "offset": 857
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "listItem",
+                          "spread": false,
+                          "checked": null,
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "(item 1.1.2.) item with tab + 4 spaces",
+                                  "position": {
+                                    "start": {
+                                      "line": 31,
+                                      "column": 8,
+                                      "offset": 865
+                                    },
+                                    "end": {
+                                      "line": 31,
+                                      "column": 46,
+                                      "offset": 903
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 31,
+                                  "column": 8,
+                                  "offset": 865
+                                },
+                                "end": {
+                                  "line": 31,
+                                  "column": 46,
+                                  "offset": 903
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 31,
+                              "column": 4,
+                              "offset": 861
+                            },
+                            "end": {
+                              "line": 31,
+                              "column": 46,
+                              "offset": 903
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "listItem",
+                          "spread": false,
+                          "checked": null,
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "(item 1.1.3.) item with 4 spaces + tab",
+                                  "position": {
+                                    "start": {
+                                      "line": 32,
+                                      "column": 8,
+                                      "offset": 911
+                                    },
+                                    "end": {
+                                      "line": 32,
+                                      "column": 46,
+                                      "offset": 949
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 32,
+                                  "column": 8,
+                                  "offset": 911
+                                },
+                                "end": {
+                                  "line": 32,
+                                  "column": 46,
+                                  "offset": 949
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 32,
+                              "column": 6,
+                              "offset": 909
+                            },
+                            "end": {
+                              "line": 32,
+                              "column": 46,
+                              "offset": 949
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "listItem",
+                          "spread": false,
+                          "checked": null,
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "(item 1.1.4.) item with tab + tab",
+                                  "position": {
+                                    "start": {
+                                      "line": 33,
+                                      "column": 5,
+                                      "offset": 954
+                                    },
+                                    "end": {
+                                      "line": 33,
+                                      "column": 38,
+                                      "offset": 987
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 33,
+                                  "column": 5,
+                                  "offset": 954
+                                },
+                                "end": {
+                                  "line": 33,
+                                  "column": 38,
+                                  "offset": 987
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 33,
+                              "column": 3,
+                              "offset": 952
+                            },
+                            "end": {
+                              "line": 33,
+                              "column": 38,
+                              "offset": 987
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "listItem",
+                          "spread": false,
+                          "checked": null,
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "(item 1.1.5.) item with 2 spaces + tab + 2 spaces (nasty!)",
+                                  "position": {
+                                    "start": {
+                                      "line": 34,
+                                      "column": 8,
+                                      "offset": 995
+                                    },
+                                    "end": {
+                                      "line": 34,
+                                      "column": 66,
+                                      "offset": 1053
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 34,
+                                  "column": 8,
+                                  "offset": 995
+                                },
+                                "end": {
+                                  "line": 34,
+                                  "column": 66,
+                                  "offset": 1053
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 34,
+                              "column": 6,
+                              "offset": 993
+                            },
+                            "end": {
+                              "line": 34,
+                              "column": 66,
+                              "offset": 1053
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 30,
+                          "column": 7,
+                          "offset": 810
+                        },
+                        "end": {
+                          "line": 34,
+                          "column": 66,
+                          "offset": 1053
+                        },
+                        "indent": [
+                          4,
+                          6,
+                          3,
+                          6
+                        ]
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 29,
+                      "column": 2,
+                      "offset": 760
+                    },
+                    "end": {
+                      "line": 34,
+                      "column": 66,
+                      "offset": 1053
+                    },
+                    "indent": [
+                      5,
+                      2,
+                      5,
+                      2,
+                      4
+                    ]
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 29,
+                  "column": 2,
+                  "offset": 760
+                },
+                "end": {
+                  "line": 34,
+                  "column": 66,
+                  "offset": 1053
+                },
+                "indent": [
+                  5,
+                  2,
+                  5,
+                  2,
+                  4
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 28,
+              "column": 1,
+              "offset": 702
+            },
+            "end": {
+              "line": 34,
+              "column": 66,
+              "offset": 1053
+            },
+            "indent": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 28,
+          "column": 1,
+          "offset": 702
+        },
+        "end": {
+          "line": 34,
+          "column": 66,
+          "offset": 1053
+        },
+        "indent": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 35,
+      "column": 1,
+      "offset": 1054
+    }
+  }
+}

--- a/test/fixtures/tree/mixed-indentation.commonmark.json
+++ b/test/fixtures/tree/mixed-indentation.commonmark.json
@@ -53,7 +53,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "Very long\n\t\t\tparagraph",
+                  "value": "Very long\n\tparagraph",
                   "position": {
                     "start": {
                       "line": 3,
@@ -66,7 +66,7 @@
                       "offset": 48
                     },
                     "indent": [
-                      0
+                      2
                     ]
                   }
                 }
@@ -83,7 +83,7 @@
                   "offset": 48
                 },
                 "indent": [
-                  0
+                  2
                 ]
               }
             }

--- a/test/fixtures/tree/mixed-indentation.json
+++ b/test/fixtures/tree/mixed-indentation.json
@@ -53,7 +53,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "Very long\n\t\t\tparagraph",
+                  "value": "Very long\n\tparagraph",
                   "position": {
                     "start": {
                       "line": 3,
@@ -66,7 +66,7 @@
                       "offset": 48
                     },
                     "indent": [
-                      0
+                      2
                     ]
                   }
                 }
@@ -83,7 +83,7 @@
                   "offset": 48
                 },
                 "indent": [
-                  0
+                  2
                 ]
               }
             }


### PR DESCRIPTION
Fixes #198

This PR introduces a new logic to determine the indentation stops when using tabs.

Before, a tab will only create an indentation stop for the whole tab. For example, a line starting with a tab character would have produced the stops ` {4: 0}`, meaning that the 4th indentation point (because tabSize=4) starts at index 0 (i.e. the first character). This was used to un-indent lists, by getting all lines that belong to the same `listItem` and looking for the biggest common indentation point. 

This is a problem when mixing spaces and tabs. Imagine a line indented with 2 spaces (it will have stops `{1:0, 2: 1}`, with 1st and 2nd indentation stops at characters 0 and 1, respectively. If the following line has an indentation of `{4: 0}` (using a tab), they won't have any common indentation stop. 

After this change, **we generate all intermediate indentation stops when using tabs**: A line starting with a tab will have stops `{1: 0, 2:0, 3:0, 4:0}`. This means that it the line above (or below) has an indentation of 1, 2, 3 or 4 spaces, both lines will be considered indented with the _same_ indentation.

The result is that, when "unindenting" a line starting with a tab, it can be "unindented" the equivalent to 1, 2, 3 or 4 spaces, and the tab will be consumed in the process.

