### PR TITLE
PoC formatting is not validated in CI

### DIFF
--- a/packages/remark/index.js
+++ b/packages/remark/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var unified = require('unified')
+var unified = require(        'unified')
 var parse = require('remark-parse')
 var stringify = require('remark-stringify')
 


### PR DESCRIPTION
This is a proof of concept to show formatting isn’t actually checked in CI.

A developer should run `prettier --write .` and `xo --fix` before committing, but CI should run `prettier --check .` and `xo` instead.