### PR TITLE
stringify: add option to not put blank lines between definitions

### DIFF
--- a/packages/remark-stringify/lib/defaults.js
+++ b/packages/remark-stringify/lib/defaults.js
@@ -11,7 +11,7 @@ module.exports = {
   tablePipeAlign: true,
   stringLength: stringLength,
   incrementListMarker: true,
-  definitionBlankLine: true,
+  tightDefinitions: false,
   fences: false,
   fence: '`',
   bullet: '-',

--- a/packages/remark-stringify/lib/defaults.js
+++ b/packages/remark-stringify/lib/defaults.js
@@ -11,6 +11,7 @@ module.exports = {
   tablePipeAlign: true,
   stringLength: stringLength,
   incrementListMarker: true,
+  definitionBlankLine: true,
   fences: false,
   fence: '`',
   bullet: '-',

--- a/packages/remark-stringify/lib/macro/block.js
+++ b/packages/remark-stringify/lib/macro/block.js
@@ -16,6 +16,7 @@ function block(node) {
   var options = self.options
   var fences = options.fences
   var gap = options.commonmark ? comment : triple
+  var definitionSeparator = options.definitionBlankLine ? blank : lineFeed
   var values = []
   var children = node.children
   var length = children.length
@@ -42,6 +43,11 @@ function block(node) {
           (child.type === 'code' && !child.lang && !fences))
       ) {
         values.push(gap)
+      } else if (
+        previous.type === 'definition' &&
+        child.type === 'definition'
+      ) {
+        values.push(definitionSeparator)
       } else {
         values.push(blank)
       }

--- a/packages/remark-stringify/lib/macro/block.js
+++ b/packages/remark-stringify/lib/macro/block.js
@@ -16,7 +16,7 @@ function block(node) {
   var options = self.options
   var fences = options.fences
   var gap = options.commonmark ? comment : triple
-  var definitionSeparator = options.definitionBlankLine ? blank : lineFeed
+  var definitionGap = options.tightDefinitions ? lineFeed : blank
   var values = []
   var children = node.children
   var length = children.length
@@ -47,7 +47,7 @@ function block(node) {
         previous.type === 'definition' &&
         child.type === 'definition'
       ) {
-        values.push(definitionSeparator)
+        values.push(definitionGap)
       } else {
         values.push(blank)
       }

--- a/packages/remark-stringify/readme.md
+++ b/packages/remark-stringify/readme.md
@@ -207,11 +207,12 @@ Increment ordered list item numbers (`boolean`, default: `true`).
 
 When `false`, all list item numbers will be the same.
 
-###### `options.definitionBlankLine`
+###### `options.tightDefinitions`
 
-Separate definitions with a blank line (`boolean`, default: `true`).
+Separate definitions with only one newline (`boolean`, default: `false`).
 
-When `false`, each pair of definitions will be separated by only one newline.
+When `false`, a definition is considered a block and separated from other blocks
+by a blank line.
 
 ###### `options.rule`
 

--- a/packages/remark-stringify/readme.md
+++ b/packages/remark-stringify/readme.md
@@ -211,8 +211,8 @@ When `false`, all list item numbers will be the same.
 
 Separate definitions with only one newline (`boolean`, default: `false`).
 
-When `false`, a definition is considered a block and separated from other blocks
-by a blank line.
+When `false`, definitions will have blank lines between them, similar to other
+blocks.
 
 ###### `options.rule`
 

--- a/packages/remark-stringify/readme.md
+++ b/packages/remark-stringify/readme.md
@@ -209,7 +209,7 @@ When `false`, all list item numbers will be the same.
 
 ###### `options.tightDefinitions`
 
-Separate definitions with only one newline (`boolean`, default: `false`).
+Separate definitions with a single line feed (`boolean`, default: `false`).
 
 When `false`, definitions will have blank lines between them, similar to other
 blocks.

--- a/packages/remark-stringify/readme.md
+++ b/packages/remark-stringify/readme.md
@@ -207,6 +207,12 @@ Increment ordered list item numbers (`boolean`, default: `true`).
 
 When `false`, all list item numbers will be the same.
 
+###### `options.definitionBlankLine`
+
+Separate definitions with a blank line (`boolean`, default: `true`).
+
+When `false`, each pair of definitions will be separated by only one newline.
+
 ###### `options.rule`
 
 Marker to use for thematic breaks / horizontal rules (`'-'`, `'*'`, or `'_'`,

--- a/packages/remark-stringify/test.js
+++ b/packages/remark-stringify/test.js
@@ -191,11 +191,11 @@ test('remark().stringify(ast, file)', function (t) {
     function () {
       unified()
         .use(stringify)
-        .data('settings', {definitionBlankLine: 'blank'})
+        .data('settings', {tightDefinitions: 'blank'})
         .stringify(empty())
     },
-    /options\.definitionBlankLine/,
-    'should throw when `options.definitionBlankLine` is not a boolean'
+    /options\.tightDefinitions/,
+    'should throw when `options.tightDefinitions` is not a boolean'
   )
 
   t.throws(
@@ -1277,13 +1277,13 @@ test('definition separators', function (t) {
   ])
 
   t.equal(
-    toString(tree, {definitionBlankLine: true}),
+    toString(tree, {tightDefinitions: false}),
     '[foo]: first\n\n[bar]: second\n',
     'blank line between definitions'
   )
 
   t.equal(
-    toString(tree, {definitionBlankLine: false}),
+    toString(tree, {tightDefinitions: true}),
     '[foo]: first\n[bar]: second\n',
     'no blank line between definitions'
   )

--- a/packages/remark-stringify/test.js
+++ b/packages/remark-stringify/test.js
@@ -191,6 +191,17 @@ test('remark().stringify(ast, file)', function (t) {
     function () {
       unified()
         .use(stringify)
+        .data('settings', {definitionBlankLine: 'blank'})
+        .stringify(empty())
+    },
+    /options\.definitionBlankLine/,
+    'should throw when `options.definitionBlankLine` is not a boolean'
+  )
+
+  t.throws(
+    function () {
+      unified()
+        .use(stringify)
         .data('settings', {fences: NaN})
         .stringify(empty())
     },
@@ -1254,6 +1265,27 @@ test('stringify escapes', function (t) {
     toString(u('paragraph', [u('text', '!'), u('link', [u('text', 'a')])])),
     '\\![a](<>)',
     '! immediately followed by a link'
+  )
+
+  t.end()
+})
+
+test('definition separators', function (t) {
+  var tree = u('root', [
+    u('definition', {identifier: 'foo', url: 'first'}),
+    u('definition', {identifier: 'bar', url: 'second'})
+  ])
+
+  t.equal(
+    toString(tree, {definitionBlankLine: true}),
+    '[foo]: first\n\n[bar]: second\n',
+    'blank line between definitions'
+  )
+
+  t.equal(
+    toString(tree, {definitionBlankLine: false}),
+    '[foo]: first\n[bar]: second\n',
+    'no blank line between definitions'
   )
 
   t.end()

--- a/packages/remark-stringify/types/index.d.ts
+++ b/packages/remark-stringify/types/index.d.ts
@@ -32,6 +32,7 @@ declare namespace remarkStringify {
     bullet: '-' | '*' | '+'
     listItemIndent: 'tab' | '1' | 'mixed'
     incrementListMarker: boolean
+    definitionBlankLine: boolean
     rule: '-' | '_' | '*'
     ruleRepetition: number
     ruleSpaces: boolean

--- a/packages/remark-stringify/types/index.d.ts
+++ b/packages/remark-stringify/types/index.d.ts
@@ -32,7 +32,7 @@ declare namespace remarkStringify {
     bullet: '-' | '*' | '+'
     listItemIndent: 'tab' | '1' | 'mixed'
     incrementListMarker: boolean
-    definitionBlankLine: boolean
+    tightDefinitions: boolean
     rule: '-' | '_' | '*'
     ruleRepetition: number
     ruleSpaces: boolean


### PR DESCRIPTION
When one has a lot of consecutive definitions, `remark-stringify` adds a lot of extra vertical space when it inserts a blank line between each definition pair. This PR provides an option to change those two newlines between definition pairs into one.

* I found GH-55 referencing this issue.
* I am neutral about the actual name of the option.