### PR TITLE
Fix broken links in CLI Readme

### DIFF
--- a/packages/remark-cli/readme.md
+++ b/packages/remark-cli/readme.md
@@ -203,9 +203,9 @@ abide by its terms.
 
 [markdown-extensions]: https://github.com/sindresorhus/markdown-extensions
 
-[config-file]: https://github.com/unifiedjs/unified-engine/blob/master/doc/configure.md
+[config-file]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
-[ignore-file]: https://github.com/unifiedjs/unified-engine/blob/master/doc/ignore.md
+[ignore-file]: https://github.com/unifiedjs/unified-engine/blob/main/doc/ignore.md
 
 [unified-args]: https://github.com/unifiedjs/unified-args#cli
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/master/support.md
https://github.com/remarkjs/.github/blob/master/contributing.md
-->

Fixes broken links to documentation in https://github.com/unifiedjs/unified-engine/