### PR TITLE
Fix using remark in typescript directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tape": "^5.0.0",
     "tinyify": "^2.0.0",
     "typescript": "^3.0.0",
-    "unified": "^9.0.0",
+    "unified": "^9.1.0",
     "unist-builder": "^2.0.0",
     "unist-util-remove-position": "^3.0.0",
     "unist-util-visit": "^2.0.0",

--- a/packages/remark/package.json
+++ b/packages/remark/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "remark-parse": "^8.0.0",
     "remark-stringify": "^8.0.0",
-    "unified": "^9.0.0"
+    "unified": "^9.1.0"
   },
   "scripts": {
     "test": "tape test.js"

--- a/packages/remark/types/index.d.ts
+++ b/packages/remark/types/index.d.ts
@@ -14,6 +14,6 @@ declare namespace remark {
   type PartialRemarkOptions = RemarkOptions
 }
 
-declare function remark(): unified.Processor<remark.RemarkOptions>
+declare const remark: unified.Processor<remark.RemarkOptions>
 
 export = remark

--- a/packages/remark/types/index.d.ts
+++ b/packages/remark/types/index.d.ts
@@ -14,6 +14,6 @@ declare namespace remark {
   type PartialRemarkOptions = RemarkOptions
 }
 
-declare const remark: unified.Processor<remark.RemarkOptions>
+declare const remark: unified.FrozenProcessor<remark.RemarkOptions>
 
 export = remark

--- a/packages/remark/types/test.ts
+++ b/packages/remark/types/test.ts
@@ -6,6 +6,7 @@ interface PluginOptions {
 
 const plugin = (options?: PluginOptions) => {}
 
+remark.parse('# Hello world!')
 remark().use(plugin)
 remark().use(plugin, {example: true})
 remark().use({settings: {commonmark: true}})


### PR DESCRIPTION
Remark exports a unified processor, not a function that returns a processor. Unified processors also happen to be functions returning a new processor, meaning the old type worked for most situations, but not all.