### PR TITLE
Ignore package-lock.json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 /remark.js
 /remark.min.js
 yarn.lock
+package-lock.json


### PR DESCRIPTION
They are generated by lerna, but the policy is to not commit them.