### PR TITLE
Fix to make all remark options optional

### DIFF
--- a/packages/remark-parse/types/index.d.ts
+++ b/packages/remark-parse/types/index.d.ts
@@ -14,8 +14,8 @@ declare class RemarkParser implements Parser {
 }
 
 declare namespace remarkParse {
-  interface Parse extends Plugin<[PartialRemarkParseOptions?]> {
-    (options: PartialRemarkParseOptions): void
+  interface Parse extends Plugin<[RemarkParseOptions?]> {
+    (options: RemarkParseOptions): void
     Parser: typeof RemarkParser
   }
 
@@ -34,7 +34,7 @@ declare namespace remarkParse {
      *
      * @defaultValue `true`
      */
-    gfm: boolean
+    gfm?: boolean
 
     /**
      * CommonMark mode
@@ -56,14 +56,14 @@ declare namespace remarkParse {
      *
      * @defaultValue `false`
      */
-    commonmark: boolean
+    commonmark?: boolean
 
     /**
      * Defines which HTML elements are seen as block level.
      *
      * @defaultValue blocks listed in <https://github.com/remarkjs/remark/blob/main/packages/remark-parse/lib/block-elements.js>
      */
-    blocks: string[]
+    blocks?: string[]
 
     /**
      * Pedantic mode
@@ -77,10 +77,13 @@ declare namespace remarkParse {
      * @defaultValue `false`
      * @deprecated pedantic mode is buggy. It won’t be in micromark, which will be the basis of a future version of remark.
      */
-    pedantic: boolean
+    pedantic?: boolean
   }
 
-  type PartialRemarkParseOptions = Partial<RemarkParseOptions>
+  /**
+   * @deprecated Use `RemarkParseOptions` instead.
+   */
+  type PartialRemarkParseOptions = RemarkParseOptions
 
   interface Add {
     (node: Node, parent?: Parent): Node

--- a/packages/remark-parse/types/test.ts
+++ b/packages/remark-parse/types/test.ts
@@ -1,7 +1,7 @@
 import unified = require('unified')
 import remarkParse = require('remark-parse')
 
-const partialParseOptions: remarkParse.PartialRemarkParseOptions = {
+const partialParseOptions: remarkParse.RemarkParseOptions = {
   gfm: true,
   pedantic: true
 }
@@ -16,13 +16,7 @@ const badParseOptions = {
 // $ExpectError
 unified().use(remarkParse, badParseOptions)
 
-// $ExpectError
-const parseOptions: remarkParse.RemarkParseOptions = {
-  gfm: true,
-  pedantic: true
-}
-
-const badParseOptionsInterface: remarkParse.PartialRemarkParseOptions = {
+const badParseOptionsInterface: remarkParse.RemarkParseOptions = {
   // $ExpectError
   gfm: 'true'
 }

--- a/packages/remark-stringify/types/index.d.ts
+++ b/packages/remark-stringify/types/index.d.ts
@@ -11,36 +11,39 @@ declare class RemarkCompiler implements Compiler {
 }
 
 declare namespace remarkStringify {
-  interface Stringify extends Plugin<[PartialRemarkStringifyOptions?]> {
+  interface Stringify extends Plugin<[RemarkStringifyOptions?]> {
     Compiler: typeof RemarkCompiler
-    (this: Processor, options?: PartialRemarkStringifyOptions): void
+    (this: Processor, options?: RemarkStringifyOptions): void
   }
 
   type Compiler = RemarkCompiler
 
   interface RemarkStringifyOptions {
-    gfm: boolean
-    commonmark: boolean
-    entities: boolean | 'numbers' | 'escape'
-    setext: boolean
-    closeAtx: boolean
-    tableCellPadding: boolean
-    tablePipeAlign: boolean
-    stringLength: (s: string) => number
-    fence: '~' | '`'
-    fences: boolean
-    bullet: '-' | '*' | '+'
-    listItemIndent: 'tab' | '1' | 'mixed'
-    incrementListMarker: boolean
-    tightDefinitions: boolean
-    rule: '-' | '_' | '*'
-    ruleRepetition: number
-    ruleSpaces: boolean
-    strong: '_' | '*'
-    emphasis: '_' | '*'
+    gfm?: boolean
+    commonmark?: boolean
+    entities?: boolean | 'numbers' | 'escape'
+    setext?: boolean
+    closeAtx?: boolean
+    tableCellPadding?: boolean
+    tablePipeAlign?: boolean
+    stringLength?: (s: string) => number
+    fence?: '~' | '`'
+    fences?: boolean
+    bullet?: '-' | '*' | '+'
+    listItemIndent?: 'tab' | '1' | 'mixed'
+    incrementListMarker?: boolean
+    tightDefinitions?: boolean
+    rule?: '-' | '_' | '*'
+    ruleRepetition?: number
+    ruleSpaces?: boolean
+    strong?: '_' | '*'
+    emphasis?: '_' | '*'
   }
 
-  type PartialRemarkStringifyOptions = Partial<RemarkStringifyOptions>
+  /**
+   * @deprecated Use `RemarkStringifyOptions` instead.
+   */
+  type PartialRemarkStringifyOptions = RemarkStringifyOptions
 
   type Visitor = (node: Node, parent?: Parent) => string
 }

--- a/packages/remark-stringify/types/test.ts
+++ b/packages/remark-stringify/types/test.ts
@@ -50,12 +50,6 @@ function gap(this: unified.Processor) {
 
 const plugin: unified.Plugin = gap
 
-const badPartialStringifyOptions: remarkStringify.PartialRemarkStringifyOptions = {
-  // $ExpectError
-  gfm: 'true'
-}
-
-// $ExpectError
 const incompleteStringifyOptions: remarkStringify.RemarkStringifyOptions = {
   gfm: true,
   fences: true,

--- a/packages/remark/types/index.d.ts
+++ b/packages/remark/types/index.d.ts
@@ -8,10 +8,12 @@ declare namespace remark {
   type RemarkOptions = remarkParse.RemarkParseOptions &
     remarkStringify.RemarkStringifyOptions
 
-  type PartialRemarkOptions = remarkParse.PartialRemarkParseOptions &
-    remarkStringify.PartialRemarkStringifyOptions
+  /**
+   * @deprecated Use `RemarkOptions` instead.
+   */
+  type PartialRemarkOptions = RemarkOptions
 }
 
-declare function remark(): unified.Processor<remark.PartialRemarkOptions>
+declare function remark(): unified.Processor<remark.RemarkOptions>
 
 export = remark

--- a/packages/remark/types/test.ts
+++ b/packages/remark/types/test.ts
@@ -14,13 +14,7 @@ remark().use({settings: {doesNotExist: true}})
 // $ExpectError
 remark().use(plugin, {doesNotExist: 'true'})
 
-// $ExpectError
-const parseOptions: remark.RemarkOptions = {
-  gfm: true,
-  pedantic: true
-}
-
-const badParseOptionsInterface: remark.PartialRemarkOptions = {
+const badParseOptionsInterface: remark.RemarkOptions = {
   // $ExpectError
   gfm: 'true'
 }


### PR DESCRIPTION
This matches the their respective call signatures.

The `Partial*Options` variants are now deprecated aliases to their matching types for backwards compatibility.