### PR TITLE
Add missing type to typescript .d.ts

### DIFF
--- a/packages/remark-parse/types/index.d.ts
+++ b/packages/remark-parse/types/index.d.ts
@@ -3,10 +3,13 @@
 import {Node, Parent, Position} from 'unist'
 import {Parser, Plugin} from 'unified'
 
-declare class RemarkParser implements Parser {
+declare class  implements Parser {
   parse(): Node
   blockMethods: string[]
   inlineTokenizers: {
+    [key: string]: remarkParse.Tokenizer
+  }
+  blockTokenizers: {
     [key: string]: remarkParse.Tokenizer
   }
 
@@ -24,7 +27,7 @@ declare namespace remarkParse {
   interface RemarkParseOptions {
     /**
      * GFM mode
-     *
+     *RemarkParser
      * Turns on:
      * * Fenced code blocks
      * * Autolinking of URLs

--- a/packages/remark-parse/types/index.d.ts
+++ b/packages/remark-parse/types/index.d.ts
@@ -3,7 +3,7 @@
 import {Node, Parent, Position} from 'unist'
 import {Parser, Plugin} from 'unified'
 
-declare class  implements Parser {
+declare class RemarkParser implements Parser {
   parse(): Node
   blockMethods: string[]
   inlineTokenizers: {
@@ -27,7 +27,7 @@ declare namespace remarkParse {
   interface RemarkParseOptions {
     /**
      * GFM mode
-     *RemarkParser
+     *
      * Turns on:
      * * Fenced code blocks
      * * Autolinking of URLs


### PR DESCRIPTION
`RemarkParser` does have `blockTokenizers` but it's missing here.

This PR trys to add missing type to `index.d.ts`.

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->
