### PR TITLE
Update types for remark@next

### DIFF
--- a/packages/remark-parse/types/index.d.ts
+++ b/packages/remark-parse/types/index.d.ts
@@ -1,11 +1,11 @@
 // TypeScript Version: 3.0
 
-import {Parser, Plugin} from 'unified'
+import {ParserFunction, Plugin} from 'unified'
 import {Options} from 'mdast-util-from-markdown'
 
 declare namespace remarkParse {
   interface Parse extends Plugin<[RemarkParseOptions?]> {
-    Parser: Parser
+    Parser: ParserFunction
   }
 
   type RemarkParseOptions = Options

--- a/packages/remark-parse/types/index.d.ts
+++ b/packages/remark-parse/types/index.d.ts
@@ -1,12 +1,10 @@
 // TypeScript Version: 3.0
 
-import {ParserFunction, Plugin} from 'unified'
+import {Plugin} from 'unified'
 import {Options} from 'mdast-util-from-markdown'
 
 declare namespace remarkParse {
-  interface Parse extends Plugin<[RemarkParseOptions?]> {
-    Parser: ParserFunction
-  }
+  interface Parse extends Plugin<[RemarkParseOptions?]> {}
 
   type RemarkParseOptions = Options
 }

--- a/packages/remark-parse/types/index.d.ts
+++ b/packages/remark-parse/types/index.d.ts
@@ -1,113 +1,16 @@
 // TypeScript Version: 3.0
 
-import {Node, Parent, Position} from 'unist'
 import {Parser, Plugin} from 'unified'
-
-declare class RemarkParser implements Parser {
-  parse(): Node
-  blockMethods: string[]
-  inlineTokenizers: {
-    [key: string]: remarkParse.Tokenizer
-  }
-  blockTokenizers: {
-    [key: string]: remarkParse.Tokenizer
-  }
-
-  inlineMethods: string[]
-}
+import {Options} from 'mdast-util-from-markdown'
 
 declare namespace remarkParse {
   interface Parse extends Plugin<[RemarkParseOptions?]> {
-    (options: RemarkParseOptions): void
-    Parser: typeof RemarkParser
+    Parser: Parser
   }
 
-  type Parser = RemarkParser
-
-  interface RemarkParseOptions {
-    /**
-     * GFM mode
-     *
-     * Turns on:
-     * * Fenced code blocks
-     * * Autolinking of URLs
-     * * Deletions (strikethrough)
-     * * Task lists
-     * * Tables
-     *
-     * @defaultValue `true`
-     */
-    gfm?: boolean
-
-    /**
-     * CommonMark mode
-     *
-     * Allows:
-     * * Empty lines to split blockquotes
-     * * Parentheses (`(` and `)`) around link and image titles
-     * * Any escaped ASCII punctuation character
-     * * Closing parenthesis (`)`) as an ordered list marker
-     * * URL definitions in blockquotes
-     *
-     * Disallows:
-     * * Indented code blocks directly following a paragraph
-     * * ATX headings (# Hash headings) without spacing after opening hashes or and before closing hashes
-     * * Setext headings (`Underline headings\n---`) when following a paragraph
-     * * Newlines in link and image titles
-     * * White space in link and image URLs in auto-links (links in brackets, `<` and `>`)
-     * * Lazy blockquote continuation, lines not preceded by a greater than character (`>`), for lists, code, and thematic breaks
-     *
-     * @defaultValue `false`
-     */
-    commonmark?: boolean
-
-    /**
-     * Defines which HTML elements are seen as block level.
-     *
-     * @defaultValue blocks listed in <https://github.com/remarkjs/remark/blob/main/packages/remark-parse/lib/block-elements.js>
-     */
-    blocks?: string[]
-
-    /**
-     * Pedantic mode
-     *
-     * Turns on:
-     * * Emphasis (`_alpha_`) and importance (`__bravo__`) with underscores in words
-     * * Unordered lists with different markers (`*`, `-`, `+`)
-     * * If commonmark is also turned on, ordered lists with different markers (`.`, `)`)
-     * * And removes less spaces in list items (at most four, instead of the whole indent)
-     *
-     * @defaultValue `false`
-     * @deprecated pedantic mode is buggy. It won’t be in micromark, which will be the basis of a future version of remark.
-     */
-    pedantic?: boolean
-  }
-
-  /**
-   * @deprecated Use `RemarkParseOptions` instead.
-   */
-  type PartialRemarkParseOptions = RemarkParseOptions
-
-  interface Add {
-    (node: Node, parent?: Parent): Node
-    test(): Position
-    reset(node: Node, parent?: Node): Node
-  }
-
-  type Eat = (value: string) => Add
-
-  type Locator = (value: string, fromIndex: number) => number
-
-  interface Tokenizer {
-    (eat: Eat, value: string, silent: true): boolean | void
-    (eat: Eat, value: string): Node | void
-    locator?: Locator
-    onlyAtStart?: boolean
-    notInBlock?: boolean
-    notInList?: boolean
-    notInLink?: boolean
-  }
+  type RemarkParseOptions = Options
 }
+
 declare const remarkParse: remarkParse.Parse
 
 export = remarkParse

--- a/packages/remark-parse/types/test.ts
+++ b/packages/remark-parse/types/test.ts
@@ -1,22 +1,7 @@
 import unified = require('unified')
 import remarkParse = require('remark-parse')
 
-const partialParseOptions: remarkParse.RemarkParseOptions = {
-  gfm: true,
-  pedantic: true
-}
-
 unified().use(remarkParse)
-unified().use(remarkParse, partialParseOptions)
-
-const badParseOptions = {
-  gfm: 'true'
-}
 
 // $ExpectError
-unified().use(remarkParse, badParseOptions)
-
-const badParseOptionsInterface: remarkParse.RemarkParseOptions = {
-  // $ExpectError
-  gfm: 'true'
-}
+unified().use(remarkParse, {unknown: 1})

--- a/packages/remark-stringify/types/index.d.ts
+++ b/packages/remark-stringify/types/index.d.ts
@@ -1,11 +1,11 @@
 // TypeScript Version: 3.0
 
-import {Compiler, Plugin} from 'unified'
+import {CompilerFunction, Plugin} from 'unified'
 import {Options} from 'mdast-util-to-markdown'
 
 declare namespace remarkStringify {
   interface Stringify extends Plugin<[RemarkStringifyOptions?]> {
-    Compiler: Compiler
+    Compiler: CompilerFunction
   }
 
   type RemarkStringifyOptions = Options

--- a/packages/remark-stringify/types/index.d.ts
+++ b/packages/remark-stringify/types/index.d.ts
@@ -1,12 +1,10 @@
 // TypeScript Version: 3.0
 
-import {CompilerFunction, Plugin} from 'unified'
+import {Plugin} from 'unified'
 import {Options} from 'mdast-util-to-markdown'
 
 declare namespace remarkStringify {
-  interface Stringify extends Plugin<[RemarkStringifyOptions?]> {
-    Compiler: CompilerFunction
-  }
+  interface Stringify extends Plugin<[RemarkStringifyOptions?]> {}
 
   type RemarkStringifyOptions = Options
 }

--- a/packages/remark-stringify/types/index.d.ts
+++ b/packages/remark-stringify/types/index.d.ts
@@ -1,51 +1,14 @@
-// TypeScript Version: 3.0
+// TypeScript Version: 3.5
 
-import {Compiler, Processor, Plugin} from 'unified'
-import {Node, Parent} from 'unist'
-
-declare class RemarkCompiler implements Compiler {
-  compile(): string
-  visitors: {
-    [key: string]: remarkStringify.Visitor
-  }
-}
+import {Compiler, Plugin} from 'unified'
+import {Options} from 'mdast-util-to-markdown'
 
 declare namespace remarkStringify {
   interface Stringify extends Plugin<[RemarkStringifyOptions?]> {
-    Compiler: typeof RemarkCompiler
-    (this: Processor, options?: RemarkStringifyOptions): void
+    Compiler: Compiler
   }
 
-  type Compiler = RemarkCompiler
-
-  interface RemarkStringifyOptions {
-    gfm?: boolean
-    commonmark?: boolean
-    entities?: boolean | 'numbers' | 'escape'
-    setext?: boolean
-    closeAtx?: boolean
-    tableCellPadding?: boolean
-    tablePipeAlign?: boolean
-    stringLength?: (s: string) => number
-    fence?: '~' | '`'
-    fences?: boolean
-    bullet?: '-' | '*' | '+'
-    listItemIndent?: 'tab' | '1' | 'mixed'
-    incrementListMarker?: boolean
-    tightDefinitions?: boolean
-    rule?: '-' | '_' | '*'
-    ruleRepetition?: number
-    ruleSpaces?: boolean
-    strong?: '_' | '*'
-    emphasis?: '_' | '*'
-  }
-
-  /**
-   * @deprecated Use `RemarkStringifyOptions` instead.
-   */
-  type PartialRemarkStringifyOptions = RemarkStringifyOptions
-
-  type Visitor = (node: Node, parent?: Parent) => string
+  type RemarkStringifyOptions = Options
 }
 
 declare const remarkStringify: remarkStringify.Stringify

--- a/packages/remark-stringify/types/index.d.ts
+++ b/packages/remark-stringify/types/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 3.5
+// TypeScript Version: 3.0
 
 import {Compiler, Plugin} from 'unified'
 import {Options} from 'mdast-util-to-markdown'

--- a/packages/remark-stringify/types/test.ts
+++ b/packages/remark-stringify/types/test.ts
@@ -13,7 +13,7 @@ unified().use(remarkStringify)
 unified().use(remarkStringify, inferredStringifyOptions)
 
 // These cannot be automatically inferred by TypeScript
-const nonInferredStringifyOptions: remarkStringify.PartialRemarkStringifyOptions = {
+const nonInferredStringifyOptions: remarkStringify.RemarkStringifyOptions = {
   fence: '~',
   bullet: '+',
   listItemIndent: 'tab',
@@ -31,27 +31,7 @@ const badStringifyOptions = {
 // $ExpectError
 unified().use(remarkStringify, badStringifyOptions)
 
-function gap(this: unified.Processor) {
-  const Compiler = this.Compiler as typeof remarkStringify.Compiler
-  const visitors = Compiler.prototype.visitors
-  const original = visitors.heading
-
-  visitors.heading = heading
-
-  function heading(this: unified.Processor, node: Node, parent?: Parent) {
-    // FIXME: remove need for explicit 'as' casting
-    const headingNode = node as Node & {depth: number}
-    return (
-      (headingNode.depth === 2 ? '\n' : '') +
-      original.apply(this, [node, parent])
-    )
-  }
-}
-
-const plugin: unified.Plugin = gap
-
 const incompleteStringifyOptions: remarkStringify.RemarkStringifyOptions = {
-  gfm: true,
   fences: true,
   incrementListMarker: false
 }

--- a/packages/remark/types/test.ts
+++ b/packages/remark/types/test.ts
@@ -9,7 +9,7 @@ const plugin = (options?: PluginOptions) => {}
 remark.parse('# Hello world!')
 remark().use(plugin)
 remark().use(plugin, {example: true})
-remark().use({settings: {commonmark: true}})
+remark().use({settings: {bullet: '+'}})
 // $ExpectError
 remark().use({settings: {doesNotExist: true}})
 // $ExpectError


### PR DESCRIPTION
Here are the type updates for the new remark-parse, remark-stringify, remark!

I tried to leave the type tests as much as they were, to reduce noise in the diff—we can clean them later.