### PR TITLE
Add `remark-remove-comments` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -197,6 +197,8 @@ The list of plugins:
     — transform to [rehype](https://github.com/rehypejs/rehype)
 *   🟢 [`remark-relative-links`](https://github.com/zslabs/remark-relative-links)
     — change absolute URLs to relative ones
+*   🟢 [`remark-remove-comments`](https://github.com/alvinometric/remark-remove-comments)
+    — remove HTML comments from the processed output
 *   🟢 [`remark-retext`](https://github.com/remarkjs/remark-retext)
     — transform to [retext](https://github.com/retextjs/retext)
 *   ⚠️ [`remark-ruby`](https://github.com/laysent/remark-ruby)


### PR DESCRIPTION
Hello everyone,

Thank you so much for your work on Remark, the ecosystem is fantastic. This PR adds my plugin [remark-remove-comments](https://github.com/alvinometric/remark-remove-comments) to the list in `plugins.md`.

This is my first plugin! Feel free to share any kind feedback, I would love that. I took inspiration from `remark-toc` for the Readme so hopefully it's clear enough. It's been tested with the latest version of Remark.

Thanks!
Alvin