### PR TITLE
docs(plugins): add remark-typedoc-symbol-links

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -255,7 +255,7 @@ The list of plugins:
     — truncate/shorten urls not manually named
 *   🟢 [`remark-twemoji`](https://github.com/madiodio/remark-twemoji)
     — turn emoji into [Twemoji](https://github.com/twitter/twemoji)
-*   🟢 [`remark-typedoc-symbol-links`](https://github.com/kamranayub/remark-typedoc-symbol-links)
+*   ⚠️ [`remark-typedoc-symbol-links`](https://github.com/kamranayub/remark-typedoc-symbol-links)
     — turn Typedoc symbol link expressions into Markdown links
 *   🟢 [`remark-typescript`](https://github.com/trevorblades/remark-typescript)
     — turn TypeScript code to JavaScript

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -255,6 +255,8 @@ The list of plugins:
     — truncate/shorten urls not manually named
 *   🟢 [`remark-twemoji`](https://github.com/madiodio/remark-twemoji)
     — turn emoji into [Twemoji](https://github.com/twitter/twemoji)
+*   🟢 [`remark-typedoc-symbol-links`](https://github.com/kamranayub/remark-typedoc-symbol-links)
+    — turn Typedoc symbol link expressions into Markdown links
 *   🟢 [`remark-typescript`](https://github.com/trevorblades/remark-typescript)
     — turn TypeScript code to JavaScript
 *   🟢 [`remark-typograf`](https://github.com/mavrin/remark-typograf)


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->

## Changes

- Add `remark-typedoc-symbol-links` to the plugins doc

## TODO

- [x] test with latest remark parser