### PR TITLE
Add `remark-img-links` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -137,6 +137,8 @@ The list of plugins:
     — new syntax to create iframes (new node type, rehype compatible)
 *   🟢 [`remark-images`](https://github.com/remarkjs/remark-images)
     — add an improved image syntax
+*   🟢 [`remark-img-links`](https://github.com/Pondorasti/remark-img-links)
+    — prefix relative image paths with an absolute URL
 *   🟢 [`remark-inline-links`](https://github.com/remarkjs/remark-inline-links)
     — change references and definitions to links and images
 *   🟢 [`remark-jargon`](https://github.com/freesewing/freesewing/tree/develop/packages/remark-jargon)


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->

## Update Documentation

I've recently written a new `remark` plugin,[`remark-img-links`](https://github.com/Pondorasti/remark-img-links), that I needed for a personal project. I thought it might be a good idea to add it to the "list of plugins" [document](https://github.com/remarkjs/remark/blob/main/doc/plugins.md).