### PR TITLE
Add `remark-torchlight` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -245,6 +245,8 @@ The list of plugins:
     — check and add the document title
 *   🟢 [`remark-toc`](https://github.com/remarkjs/remark-toc)
     — add a table of contents
+*   🟢 [`remark-torchlight`](https://github.com/torchlight-api/remark-torchlight)
+    — syntax highlighting powered by [torchlight.dev](https://torchlight.dev)
 *   🟢 [`remark-tree-sitter`](https://github.com/samlanning/remark-tree-sitter)
     — highlight code blocks in markdown files using
     [Tree-sitter](https://tree-sitter.github.io/tree-sitter/)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Adds [`remark-torchlight`](https://github.com/torchlight-api/remark-torchlight) to plugins list. Thanks!

<!--do not edit: pr-->
