### PR TITLE
Add `remark-cite` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -52,6 +52,8 @@ The list of plugins:
     – hard breaks w/o needing spaces (like on issues)
 *   🟢 [`remark-capitalize`](https://github.com/zeit/remark-capitalize)
     – transform all titles w/ [`title.sh`](https://github.com/zeit/title)
+*   🟢 [`remark-cite`](https://github.com/benrbray/remark-cite)
+    – new syntax for Pandoc-style citations
 *   🟢 [`remark-code-blocks`](https://github.com/mrzmmr/remark-code-blocks)
     — select and store code blocks
 *   🟢 [`remark-code-extra`](https://github.com/samlanning/remark-code-extra)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Add [`remark-cite`](https://github.com/benrbray/remark-cite) to the list of remark plugins.

<!--do not edit: pr-->
