### PR TITLE
Update test for change in upstream dependencies

### DIFF
--- a/packages/remark-stringify/test.js
+++ b/packages/remark-stringify/test.js
@@ -429,7 +429,7 @@ test('stringify escapes', (t) => {
   t.equal(toString('![a'), '!\\[a\n', 'the `[` in `![`')
   t.equal(toString('a~b'), 'a~b\n', '`~`')
   t.equal(toString('a|b'), 'a|b\n', '`|`')
-  t.equal(toString('a_b'), 'a_b\n', '`_` (in words)')
+  t.equal(toString('a_b'), 'a\\_b\n', '`_` (in words)')
   t.equal(toString('a _b'), 'a \\_b\n', '`_` after `\\b`')
   t.equal(toString('a_ b'), 'a\\_ b\n', '`_` before `\\b`')
   t.equal(toString('a:b'), 'a:b\n', '`:`')


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Running `npm test` in `remark-stringify` has one failing test, I believe due to a change in an upstream dependency. This change adusts the test expectation.

<!--do not edit: pr-->
