### PR TITLE
remark-stringify: fix types to disallow `options.extensions`

### DIFF
--- a/packages/remark-stringify/lib/index.js
+++ b/packages/remark-stringify/lib/index.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('mdast').Root|import('mdast').Content} Node
- * @typedef {import('mdast-util-to-markdown').Options} Options
+ * @typedef {import('mdast-util-to-markdown').Options} ToMarkdownOptions
+ * @typedef {Omit<ToMarkdownOptions, 'extensions'>} Options
  */
 
 import {toMarkdown} from 'mdast-util-to-markdown'
@@ -18,7 +19,10 @@ export default function remarkStringify(options) {
         // Note: this option is not in the readme.
         // The goal is for it to be set by plugins on `data` instead of being
         // passed by users.
-        extensions: this.data('toMarkdownExtensions') || []
+        extensions:
+          /** @type {ToMarkdownOptions['extensions']} */ (
+            this.data('toMarkdownExtensions')
+          ) || []
       })
     )
   }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

As title

<!--do not edit: pr-->
