### PR TITLE
Add `remark-directive-rehype` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -92,8 +92,7 @@ The list of plugins:
 *   🟢 [`remark-directive`](https://github.com/remarkjs/remark-directive)
     — new syntax for directives (generic extensions)
 *   🟢 [`remark-directive-rehype`](https://github.com/IGassmann/remark-directive-rehype)
-    — enable Markdown directives to be parsed as HTML with
-    [`remark-directive`][d] and [`remark-rehype`](https://github.com/remarkjs/remark-rehype)
+    — turn [directives][d] into HTML custom elements (rehype compatible)
 *   🟢 [`remark-dropcap`](https://github.com/brev/remark-dropcap)
     — fancy and accessible drop caps
 *   🟢 [`remark-embed-images`](https://github.com/remarkjs/remark-embed-images)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -91,6 +91,8 @@ The list of plugins:
     — turn some or all remark’s tokenizers on or off
 *   🟢 [`remark-directive`](https://github.com/remarkjs/remark-directive)
     — new syntax for directives (generic extensions)
+*   🟢 [`remark-directive-rehype`](https://github.com/IGassmann/remark-directive-rehype)
+    — enable Markdown directives to be parsed as HTML with [`remark-directive`][d] and [`remark-rehype`](https://github.com/remarkjs/remark-rehype)
 *   🟢 [`remark-dropcap`](https://github.com/brev/remark-dropcap)
     — fancy and accessible drop caps
 *   🟢 [`remark-embed-images`](https://github.com/remarkjs/remark-embed-images)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -92,7 +92,8 @@ The list of plugins:
 *   🟢 [`remark-directive`](https://github.com/remarkjs/remark-directive)
     — new syntax for directives (generic extensions)
 *   🟢 [`remark-directive-rehype`](https://github.com/IGassmann/remark-directive-rehype)
-    — enable Markdown directives to be parsed as HTML with [`remark-directive`][d] and [`remark-rehype`](https://github.com/remarkjs/remark-rehype)
+    — enable Markdown directives to be parsed as HTML with [`remark-directive`][d] and
+    [`remark-rehype`](https://github.com/remarkjs/remark-rehype)
 *   🟢 [`remark-dropcap`](https://github.com/brev/remark-dropcap)
     — fancy and accessible drop caps
 *   🟢 [`remark-embed-images`](https://github.com/remarkjs/remark-embed-images)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -92,8 +92,8 @@ The list of plugins:
 *   🟢 [`remark-directive`](https://github.com/remarkjs/remark-directive)
     — new syntax for directives (generic extensions)
 *   🟢 [`remark-directive-rehype`](https://github.com/IGassmann/remark-directive-rehype)
-    — enable Markdown directives to be parsed as HTML with [`remark-directive`][d] and
-    [`remark-rehype`](https://github.com/remarkjs/remark-rehype)
+    — enable Markdown directives to be parsed as HTML with
+    [`remark-directive`][d] and [`remark-rehype`](https://github.com/remarkjs/remark-rehype)
 *   🟢 [`remark-dropcap`](https://github.com/brev/remark-dropcap)
     — fancy and accessible drop caps
 *   🟢 [`remark-embed-images`](https://github.com/remarkjs/remark-embed-images)


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This adds [`remark-directive-rehype`](https://github.com/IGassmann/remark-directive-rehype) to the list of remark plugins. It enables Markdown directives to be parsed as HTML when using `remark-directive` and `remark-rehype`.

<!--do not edit: pr-->