### PR TITLE
Add `remark-prettier` to list of plugin

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -184,7 +184,7 @@ The list of plugins:
     — new syntax for mentions w/ configurable existence check (new node
     type, rehype compatible)
 *   🟢 [`remark-prettier`](https://github.com/remcohaszing/remark-prettier)
-    — Check and format markdown using Prettier as a remark plugin
+    — check and format markdown using Prettier
 *   🟢 [`remark-prism`](https://github.com/sergioramos/remark-prism)
     — highlight code blocks w/ [Prism](https://prismjs.com/) (supporting most
     Prism plugins)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -183,6 +183,8 @@ The list of plugins:
 *   ⚠️ [`remark-ping`](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-ping#readme)
     — new syntax for mentions w/ configurable existence check (new node
     type, rehype compatible)
+*   🟢 [`remark-prettier`](https://github.com/remcohaszing/remark-prettier)
+    — Check and format markdown using Prettier as a remark plugin
 *   🟢 [`remark-prism`](https://github.com/sergioramos/remark-prism)
     — highlight code blocks w/ [Prism](https://prismjs.com/) (supporting most
     Prism plugins)


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Add [`remark-prettier`](https://github.com/remcohaszing/remark-prettier) to the plugin list in docs.

<!--do not edit: pr-->
