### PR TITLE
Add `remark-mermaidjs` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -165,6 +165,8 @@ The list of plugins:
     — new syntax for math (new node types, rehype compatible)
 *   🟢 [`remark-mdx`](https://github.com/mdx-js/mdx/tree/main/packages/remark-mdx)
     — support MDX (JSX, expressions, ESM)
+*   🟢 [`remark-mermaidjs`](https://github.com/remcohaszing/remark-mermaidjs)
+    — transform mermaid code blocks into inline SVGs
 *   🟢 [`remark-message-control`](https://github.com/remarkjs/remark-message-control)
     — turn some or all messages on or off
 *   🟢 [`remark-normalize-headings`](https://github.com/remarkjs/remark-normalize-headings)


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Add [`remark-mermaidjs`](https://github.com/remcohaszing/remark-mermaidjs) to the list of remark plugins.

<!--do not edit: pr-->
