### PR TITLE
Add remark-language-server package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "packages/remark-parse",
     "packages/remark-stringify",
     "packages/remark",
-    "packages/remark-cli"
+    "packages/remark-cli",
+    "packages/remark-language-server"
   ],
   "devDependencies": {
     "@types/mdast": "^3.0.0",

--- a/packages/remark-language-server/.npmrc
+++ b/packages/remark-language-server/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/remark-language-server/package.json
+++ b/packages/remark-language-server/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "remark-language-server",
+  "version": "1.0.0",
+  "description": "A language server for markdown using remark",
+  "homepage": "https://remark.js.org",
+  "repository": "https://github.com/remarkjs/remark/tree/main/packages/remark-language-server",
+  "bugs": "https://github.com/remarkjs/remark-language-serve/issues",
+  "bin": "remark-language-server.js",
+  "author": "Remco Haszing <remcohaszing@gmail.com>",
+  "license": "MIT",
+  "type": "module",
+  "files": [
+    "remark-language-server.js"
+  ],
+  "scripts": {
+    "format": "remark . -qfo && prettier . -w --loglevel warn && xo --fix",
+    "test": "tsc && npm run format"
+  },
+  "prettier": {
+    "tabWidth": 2,
+    "useTabs": false,
+    "singleQuote": true,
+    "bracketSpacing": false,
+    "semi": false,
+    "trailingComma": "none"
+  },
+  "keywords": [
+    "unified",
+    "remark",
+    "markdown",
+    "mdast",
+    "lsp",
+    "languageserver",
+    "language server",
+    "cli"
+  ],
+  "dependencies": {
+    "unified-language-server": "^1.0.0"
+  }
+}

--- a/packages/remark-language-server/readme.md
+++ b/packages/remark-language-server/readme.md
@@ -1,0 +1,207 @@
+# remark-language-server
+
+[![Build][build-badge]][build]
+[![Coverage][coverage-badge]][coverage]
+[![Downloads][downloads-badge]][downloads]
+[![Sponsors][sponsors-badge]][collective]
+[![Backers][backers-badge]][collective]
+[![Chat][chat-badge]][chat]
+
+A language server to lint and format markdown files with **[remark][]**.
+
+## Contents
+
+*   [What is this?](#what-is-this)
+*   [When should I use this?](#when-should-i-use-this)
+*   [Install](#install)
+*   [Use](#use)
+*   [CLI](#cli)
+*   [Compatibility](#compatibility)
+*   [Contribute](#contribute)
+*   [Sponsor](#sponsor)
+*   [License](#license)
+
+## What is this?
+
+This package is a [language server][] which can lint and format markdown files
+using remark.
+
+You can choose from the 150+ plugins that already exist or make your own.
+
+See [the monorepo readme][remark] for info on what the remark ecosystem is.
+
+## When should I use this?
+
+You can use this package when you want to enhance your editor with linting and
+formatting of markdown files.
+Some editors can consume this package directly, others need a plugin in order to
+consume this package.
+
+## Install
+
+This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
+In Node.js (version 12.20+, 14.14+, or 16.0+), install with [npm][]:
+
+```sh
+npm install remark-language-server
+```
+
+## Use
+
+Usage of this package depends on your editor integration.
+
+Practical examples are coming soon.
+
+## CLI
+
+The interface of `remark-language-server` is explained as follows on its help
+page (`language-server --help`):
+
+```txt
+Usage: remark-language-server [options]
+
+  A language server for markdown using remark
+
+Options:
+
+  --node-ipc       Use the node-ipc protocol
+  --stdio          Use stdio for communication  (Default: true)
+  --socket [port]  Use a socket
+  --pipe [name]    Use a pipe
+```
+
+`remark-language-server` uses the same configuration files as [remark-cli][].
+
+## Compatibility
+
+Projects maintained by the unified collective are compatible with all maintained
+versions of Node.js.
+As of now, that is Node.js 12.20+, 14.14+, and 16.0+.
+Our projects sometimes work with older versions, but this is not guaranteed.
+
+## Contribute
+
+See [`contributing.md`][contributing] in [`remarkjs/.github`][health] for ways
+to get started.
+See [`support.md`][support] for ways to get help.
+Join us in [Discussions][chat] to chat with the community and contributors.
+
+This project has a [code of conduct][coc].
+By interacting with this repository, organization, or community you agree to
+abide by its terms.
+
+## Sponsor
+
+Support this effort and give back by sponsoring on [OpenCollective][collective]!
+
+<!--lint ignore no-html-->
+
+<table>
+<tr valign="middle">
+<td width="20%" align="center" rowspan="2" colspan="2">
+  <a href="https://vercel.com">Vercel</a><br><br>
+  <a href="https://vercel.com"><img src="https://avatars1.githubusercontent.com/u/14985020?s=256&v=4" width="128"></a>
+</td>
+<td width="20%" align="center" rowspan="2" colspan="2">
+  <a href="https://motif.land">Motif</a><br><br>
+  <a href="https://motif.land"><img src="https://avatars1.githubusercontent.com/u/74457950?s=256&v=4" width="128"></a>
+</td>
+<td width="20%" align="center" rowspan="2" colspan="2">
+  <a href="https://www.hashicorp.com">HashiCorp</a><br><br>
+  <a href="https://www.hashicorp.com"><img src="https://avatars1.githubusercontent.com/u/761456?s=256&v=4" width="128"></a>
+</td>
+<td width="20%" align="center" rowspan="2" colspan="2">
+  <a href="https://www.gatsbyjs.org">Gatsby</a><br><br>
+  <a href="https://www.gatsbyjs.org"><img src="https://avatars1.githubusercontent.com/u/12551863?s=256&v=4" width="128"></a>
+</td>
+<td width="20%" align="center" rowspan="2" colspan="2">
+  <a href="https://www.netlify.com">Netlify</a><br><br>
+  <!--OC has a sharper image-->
+  <a href="https://www.netlify.com"><img src="https://images.opencollective.com/netlify/4087de2/logo/256.png" width="128"></a>
+</td>
+</tr>
+<tr valign="middle">
+</tr>
+<tr valign="middle">
+<td width="10%" align="center">
+  <a href="https://www.coinbase.com">Coinbase</a><br><br>
+  <a href="https://www.coinbase.com"><img src="https://avatars1.githubusercontent.com/u/1885080?s=256&v=4" width="64"></a>
+</td>
+<td width="10%" align="center">
+  <a href="https://themeisle.com">ThemeIsle</a><br><br>
+  <a href="https://themeisle.com"><img src="https://avatars1.githubusercontent.com/u/58979018?s=128&v=4" width="64"></a>
+</td>
+<td width="10%" align="center">
+  <a href="https://expo.io">Expo</a><br><br>
+  <a href="https://expo.io"><img src="https://avatars1.githubusercontent.com/u/12504344?s=128&v=4" width="64"></a>
+</td>
+<td width="10%" align="center">
+  <a href="https://boosthub.io">Boost Hub</a><br><br>
+  <a href="https://boosthub.io"><img src="https://images.opencollective.com/boosthub/6318083/logo/128.png" width="64"></a>
+</td>
+<td width="10%" align="center">
+  <a href="https://www.holloway.com">Holloway</a><br><br>
+  <a href="https://www.holloway.com"><img src="https://avatars1.githubusercontent.com/u/35904294?s=128&v=4" width="64"></a>
+</td>
+<td width="10%"></td>
+<td width="10%"></td>
+<td width="10%"></td>
+<td width="10%"></td>
+<td width="10%"></td>
+</tr>
+<tr valign="middle">
+<td width="100%" align="center" colspan="10">
+  <br>
+  <a href="https://opencollective.com/unified"><strong>You?</strong></a>
+  <br><br>
+</td>
+</tr>
+</table>
+
+## License
+
+[MIT][license] © [Titus Wormer][author]
+
+<!-- Definitions -->
+
+[build-badge]: https://github.com/remarkjs/remark/workflows/main/badge.svg
+
+[build]: https://github.com/remarkjs/remark/actions
+
+[coverage-badge]: https://img.shields.io/codecov/c/github/remarkjs/remark.svg
+
+[coverage]: https://codecov.io/github/remarkjs/remark
+
+[downloads-badge]: https://img.shields.io/npm/dm/remark-cli.svg
+
+[downloads]: https://www.npmjs.com/package/remark-cli
+
+[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
+
+[backers-badge]: https://opencollective.com/unified/backers/badge.svg
+
+[collective]: https://opencollective.com/unified
+
+[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
+
+[chat]: https://github.com/remarkjs/remark/discussions
+
+[health]: https://github.com/remarkjs/.github
+
+[contributing]: https://github.com/remarkjs/.github/blob/main/contributing.md
+
+[support]: https://github.com/remarkjs/.github/blob/main/support.md
+
+[coc]: https://github.com/remarkjs/.github/blob/main/code-of-conduct.md
+
+[license]: https://github.com/remarkjs/remark/blob/main/license
+
+[author]: https://wooorm.com
+
+[npm]: https://docs.npmjs.com/cli/install
+
+[language server]: https://microsoft.github.io/language-server-protocol/
+
+[remark]: https://github.com/remarkjs/remark
+
+[remark-cli]: https://github.com/remarkjs/remark/tree/main/packages/remark-cli

--- a/packages/remark-language-server/readme.md
+++ b/packages/remark-language-server/readme.md
@@ -24,7 +24,7 @@ A language server to lint and format markdown files with **[remark][]**.
 ## What is this?
 
 This package is a [language server][] which can lint and format markdown files
-using remark.
+directly in your editor using remark.
 
 You can choose from the 150+ plugins that already exist or make your own.
 

--- a/packages/remark-language-server/remark-language-server.js
+++ b/packages/remark-language-server/remark-language-server.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import {createUnifiedLanguageServer} from 'unified-language-server'
+
+process.title = 'remark-language-server'
+
+createUnifiedLanguageServer({
+  ignoreName: '.remarkignore',
+  packageField: 'remarkConfig',
+  pluginPrefix: 'remark',
+  plugins: ['remark-parse', 'remark-stringify'],
+  rcName: '.remarkrc'
+})

--- a/packages/remark-language-server/tsconfig.json
+++ b/packages/remark-language-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "include": ["*.js"],
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "checkJs": true,
+    "declaration": true,
+    "lib": ["ES2020"],
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2020"
+  }
+}


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This provides language server support for remark based on https://github.com/unifiedjs/unified-language-server/pull/13

Initially I was going to create this as a separate project, but maybe it belongs in the remark core project. Regardless, I think it belongs in the remark organization and at least now it’s no longer just a local project on my machine. :)

<!--do not edit: pr-->
