### PR TITLE
Add `@vcarl/remark-headings` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -128,7 +128,7 @@ The list of plugins:
 *   🟢 [`remark-heading-gap`](https://github.com/remarkjs/remark-heading-gap)
     — serialize w/ more blank lines between headings
 *   🟢 [`remark-headings`](https://github.com/vcarl/remark-headings)
-    - extract a list of headings as data
+    — extract a list of headings as data
 *   🟢 [`remark-highlight.js`](https://github.com/remarkjs/remark-highlight.js)
     — highlight code blocks w/ [highlight.js](https://github.com/isagalaev/highlight.js)
     (rehype compatible)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -127,7 +127,7 @@ The list of plugins:
     — custom heading id support `{#custom-id}`
 *   🟢 [`remark-heading-gap`](https://github.com/remarkjs/remark-heading-gap)
     — serialize w/ more blank lines between headings
-*   🟢 [`remark-headings`](https://github.com/vcarl/remark-headings)
+*   🟢 [`@vcarl/remark-headings`](https://github.com/vcarl/remark-headings)
     — extract a list of headings as data
 *   🟢 [`remark-highlight.js`](https://github.com/remarkjs/remark-highlight.js)
     — highlight code blocks w/ [highlight.js](https://github.com/isagalaev/highlight.js)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -127,6 +127,8 @@ The list of plugins:
     — custom heading id support `{#custom-id}`
 *   🟢 [`remark-heading-gap`](https://github.com/remarkjs/remark-heading-gap)
     — serialize w/ more blank lines between headings
+*   🟢 [`remark-headings`](https://github.com/vcarl/remark-headings)
+    - extract a list of headings as data
 *   🟢 [`remark-highlight.js`](https://github.com/remarkjs/remark-highlight.js)
     — highlight code blocks w/ [highlight.js](https://github.com/isagalaev/highlight.js)
     (rehype compatible)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I wrote a plugin to replicate functionality I got from Gatsby when migrating away from it, thought it would be helpful to others!

```
const vfile = await processor.process(input);
console.log(vfile.data.headings)
// Yields:
[
  {"depth": 1, "value": "Heading 1"},
  {"depth": 2, "value": "Heading 2"},
  {"depth": 3, "value": "Heading 3"},
]
```

<!--do not edit: pr-->
