### PR TITLE
Add `remark-docx` and `remark-pdf` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -93,6 +93,8 @@ The list of plugins:
     — new syntax for directives (generic extensions)
 *   🟢 [`remark-directive-rehype`](https://github.com/IGassmann/remark-directive-rehype)
     — turn [directives][d] into HTML custom elements (rehype compatible)
+*   🟢 [`remark-docx`](https://github.com/inokawa/remark-docx)
+    — compile markdown to docx
 *   🟢 [`remark-dropcap`](https://github.com/brev/remark-dropcap)
     — fancy and accessible drop caps
 *   🟢 [`remark-embed-images`](https://github.com/remarkjs/remark-embed-images)
@@ -184,6 +186,8 @@ The list of plugins:
     — inject your dependencies
 *   ⚠️ [`remark-parse-yaml`](https://github.com/landakram/remark-parse-yaml)
     — parse YAML nodes and expose their value as `parsedValue`
+*   🟢 [`remark-pdf`](https://github.com/inokawa/remark-pdf)
+    — compile markdown to pdf
 *   ⚠️ [`remark-ping`](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-ping#readme)
     — new syntax for mentions w/ configurable existence check (new node
     type, rehype compatible)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Add `remark-docx` and `remark-pdf` to list of plugins

<!--do not edit: pr-->
