### PR TITLE
Adds remark-mdx-postcss plugin to list

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -169,6 +169,8 @@ The list of plugins:
     — new syntax for math (new node types, rehype compatible)
 *   🟢 [`remark-mdx`](https://github.com/mdx-js/mdx/tree/main/packages/remark-mdx)
     — support MDX (JSX, expressions, ESM)
+*   🟢 [`remark-mdx-postcss`](https://github.com/SSHari/remark-mdx-postcss)
+    — create a dynamic style tag for MDX via postcss
 *   🟢 [`remark-mermaidjs`](https://github.com/remcohaszing/remark-mermaidjs)
     — transform mermaid code blocks into inline SVGs
 *   🟢 [`remark-message-control`](https://github.com/remarkjs/remark-message-control)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Add the `remark-mdx-postcss` plugin to the plugins page. The plugin is designed to create a dynamic style tag for MDX which makes it easier to create isolated MDX bundles.

[remark-mdx-postcss](https://github.com/SSHari/remark-mdx-postcss)

<!--do not edit: pr-->
