### PR TITLE
Rewrite import path to allow mdast-util-from-markdown type to resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "xo": "^0.50.0"
   },
   "scripts": {
-    "build": "npm run build --workspaces && rimraf \"*.d.ts\" \"{test,script}/**/*.d.ts\" && tsc && type-coverage",
+    "build": "npm run build --workspaces && rimraf \"*.d.ts\" \"{test,script}/**/*.d.ts\" && tsc && node ./script/convert-shallow-path-remark-parse.js && type-coverage",
     "format": "./packages/remark-cli/cli.js . -qfo && prettier . -w --loglevel warn && xo --fix",
     "test-api": "npm run test --workspaces && node --conditions development test/index.js",
     "test-coverage": "c8 --check-coverage --branches 100 --functions 100 --lines 100 --statements 100 --reporter lcov npm run test-api",

--- a/packages/remark-parse/package.json
+++ b/packages/remark-parse/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@types/mdast": "^3.0.0",
-    "mdast-util-from-markdown": "^1.0.0",
+    "mdast-util-from-markdown": "^1.2.0",
     "unified": "^10.0.0"
   },
   "scripts": {

--- a/script/convert-shallow-path-remark-parse.js
+++ b/script/convert-shallow-path-remark-parse.js
@@ -1,0 +1,29 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const targetTypeFile = path.join(
+  'packages',
+  'remark-parse',
+  'lib',
+  'index.d.ts'
+)
+if (!fs.existsSync(targetTypeFile)) {
+  throw new Error('Cannot find `' + targetTypeFile + '`')
+}
+
+const content = fs.readFileSync(targetTypeFile, 'utf-8')
+
+/**
+ * NOTE: In ../packages/remark-parse/lib/index.js , we use `typedef` specify the import path as "mdast-util-from-markdown",
+ * but due to the issue in https://github.com/microsoft/TypeScript/issues/38111 ,
+ * it is replaced by the shortest path.
+ * Since the path cannot be referenced, we replace with an entrypoint that types were re-exported.
+ * @see https://github.com/remarkjs/remark/issues/1039
+ */
+
+const replaced = content.replace(
+  'import("mdast-util-from-markdown/lib")',
+  'import("mdast-util-from-markdown")'
+)
+
+fs.writeFileSync(targetTypeFile, replaced)

--- a/script/convert-shallow-path-remark-parse.js
+++ b/script/convert-shallow-path-remark-parse.js
@@ -11,7 +11,7 @@ if (!fs.existsSync(targetTypeFile)) {
   throw new Error('Cannot find `' + targetTypeFile + '`')
 }
 
-const content = fs.readFileSync(targetTypeFile, 'utf-8')
+const content = fs.readFileSync(targetTypeFile, 'utf8')
 
 /**
  * NOTE: In ../packages/remark-parse/lib/index.js , we use `typedef` specify the import path as "mdast-util-from-markdown",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

ref: https://github.com/remarkjs/remark/issues/1039

I edited the output type definition file because output of the TypeScript compiler cannot be controlled.

<!--do not edit: pr-->
