### PR TITLE
Remove deprecated `remark-jargon`

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -148,8 +148,6 @@ The list of plugins:
     — prefix relative image paths with an absolute URL
 *   🟢 [`remark-inline-links`](https://github.com/remarkjs/remark-inline-links)
     — change references and definitions to links and images
-*   🟢 [`remark-jargon`](https://github.com/freesewing/freesewing/tree/develop/packages/remark-jargon)
-    — inserts definitions for jargon terms
 *   🟢 [`remark-join-cjk-lines`](https://github.com/purefun/remark-join-cjk-lines)
     — remove extra space between CJK Characters.
 *   ⚠️ [`remark-kbd`](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-kbd#readme)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [X] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [X] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [X] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [X] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [X] If applicable, I’ve added docs and tests

### Description of changes

Update the link of `remark-jargon` with a note stating is now deprecated and moved to `rehype`

<!--do not edit: pr-->
