### PR TITLE
Fix CVE-2020-7753

### DIFF
--- a/packages/remark-cli/test.js
+++ b/packages/remark-cli/test.js
@@ -41,6 +41,7 @@ test('remark-cli', function (t) {
           '      --file-path <path>                  specify path to process as',
           '      --ignore-path-resolve-from dir|cwd  resolve patterns in `ignore-path` from its directory or cwd',
           '      --ignore-pattern <globs>            specify ignore patterns',
+          '      --silently-ignore                   do not fail when given ignored files',
           '      --tree-in                           specify input as syntax tree',
           '      --tree-out                          output syntax tree',
           '      --inspect                           output formatted syntax tree',

--- a/packages/remark-parse/index.js
+++ b/packages/remark-parse/index.js
@@ -2,7 +2,7 @@
 
 var unherit = require('unherit')
 var xtend = require('xtend')
-var Parser = require('./lib/parser.js')
+var Parser = require('./lib/parser')
 
 module.exports = parse
 parse.Parser = Parser

--- a/packages/remark-parse/lib/tokenize/list.js
+++ b/packages/remark-parse/lib/tokenize/list.js
@@ -23,7 +23,8 @@ var lowercaseX = 'x'
 var tabSize = 4
 var looseListItemExpression = /\n\n(?!\s*$)/
 var taskItemExpression = /^\[([ X\tx])][ \t]/
-var bulletExpression = /^([ \t]*)([*+-]|\d+[.)])( {1,4}(?! )| |\t|$|(?=\n))([^\n]*)/
+var bulletExpression =
+  /^([ \t]*)([*+-]|\d+[.)])( {1,4}(?! )| |\t|$|(?=\n))([^\n]*)/
 var pedanticBulletExpression = /^([ \t]*)([*+-]|\d+[.)])([ \t]+)/
 var initialIndentExpression = /^( {1,4}|\t)?/gm
 

--- a/packages/remark-parse/package.json
+++ b/packages/remark-parse/package.json
@@ -48,7 +48,7 @@
     "parse-entities": "^2.0.0",
     "repeat-string": "^1.5.4",
     "state-toggle": "^1.0.0",
-    "trim": "0.0.1",
+    "trim": "1.0.1",
     "trim-trailing-lines": "^1.0.0",
     "unherit": "^1.0.4",
     "unist-util-remove-position": "^2.0.0",

--- a/packages/remark-stringify/index.js
+++ b/packages/remark-stringify/index.js
@@ -2,7 +2,7 @@
 
 var unherit = require('unherit')
 var xtend = require('xtend')
-var Compiler = require('./lib/compiler.js')
+var Compiler = require('./lib/compiler')
 
 module.exports = stringify
 stringify.Compiler = Compiler

--- a/packages/remark-stringify/test.js
+++ b/packages/remark-stringify/test.js
@@ -250,33 +250,34 @@ test('remark().stringify(ast, file)', function (t) {
     'should throw when `options.stringLength` is not a function'
   )
 
-  t.test('should handle underscores in emphasis in pedantic mode', function (
-    st
-  ) {
-    st.plan(2)
+  t.test(
+    'should handle underscores in emphasis in pedantic mode',
+    function (st) {
+      st.plan(2)
 
-    var example = '*alpha_bravo*\n'
+      var example = '*alpha_bravo*\n'
 
-    // Without pedantic mode, emphasis always defaults to underscores.
-    st.equal(
-      unified().use(parse).use(stringify).processSync(example).toString(),
-      '_alpha_bravo_\n',
-      'baseline'
-    )
+      // Without pedantic mode, emphasis always defaults to underscores.
+      st.equal(
+        unified().use(parse).use(stringify).processSync(example).toString(),
+        '_alpha_bravo_\n',
+        'baseline'
+      )
 
-    // With pedantic mode, emphasis will default to asterisks if the text to be
-    // emphasized contains underscores.
-    st.equal(
-      unified()
-        .use(parse)
-        .use(stringify)
-        .use({settings: {pedantic: true}})
-        .processSync(example)
-        .toString(),
-      '*alpha\\_bravo*\n',
-      'pedantic'
-    )
-  })
+      // With pedantic mode, emphasis will default to asterisks if the text to be
+      // emphasized contains underscores.
+      st.equal(
+        unified()
+          .use(parse)
+          .use(stringify)
+          .use({settings: {pedantic: true}})
+          .processSync(example)
+          .toString(),
+        '*alpha\\_bravo*\n',
+        'pedantic'
+      )
+    }
+  )
 
   t.test('should support optional list fields', function (st) {
     st.equal(

--- a/packages/remark-stringify/types/test.ts
+++ b/packages/remark-stringify/types/test.ts
@@ -13,14 +13,15 @@ unified().use(remarkStringify)
 unified().use(remarkStringify, inferredStringifyOptions)
 
 // These cannot be automatically inferred by TypeScript
-const nonInferredStringifyOptions: remarkStringify.PartialRemarkStringifyOptions = {
-  fence: '~',
-  bullet: '+',
-  listItemIndent: 'tab',
-  rule: '-',
-  strong: '_',
-  emphasis: '*'
-}
+const nonInferredStringifyOptions: remarkStringify.PartialRemarkStringifyOptions =
+  {
+    fence: '~',
+    bullet: '+',
+    listItemIndent: 'tab',
+    rule: '-',
+    strong: '_',
+    emphasis: '*'
+  }
 
 unified().use(remarkStringify, nonInferredStringifyOptions)
 
@@ -50,10 +51,11 @@ function gap(this: unified.Processor) {
 
 const plugin: unified.Plugin = gap
 
-const badPartialStringifyOptions: remarkStringify.PartialRemarkStringifyOptions = {
-  // $ExpectError
-  gfm: 'true'
-}
+const badPartialStringifyOptions: remarkStringify.PartialRemarkStringifyOptions =
+  {
+    // $ExpectError
+    gfm: 'true'
+  }
 
 // $ExpectError
 const incompleteStringifyOptions: remarkStringify.RemarkStringifyOptions = {

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -4,8 +4,8 @@ var fs = require('fs')
 var path = require('path')
 var camelcase = require('camelcase')
 var clone = require('clone')
-var parseDefaults = require('../../packages/remark-parse/lib/defaults.js')
-var stringifyDefaults = require('../../packages/remark-stringify/lib/defaults.js')
+var parseDefaults = require('../../packages/remark-parse/lib/defaults')
+var stringifyDefaults = require('../../packages/remark-stringify/lib/defaults')
 
 var own = {}.hasOwnProperty
 var read = fs.readFileSync


### PR DESCRIPTION
Update trim to v1.0.1

https://github.com/advisories/GHSA-w5p7-h5w8-2hfq

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I would like to propose a patch to v8 of remark-parse, unfortunately there are no separate branches so I am unsure how to proceed but I will base `main` for now and hope that a maintainer can provide a way to release a patch for v8. 

This patch simply updates `trim` from 0.0.1 with known [CVE-2020-7753](https://github.com/advisories/GHSA-w5p7-h5w8-2hfq) to 1.0.1. 

This obviously cannot be merged into `main` but I will open a PR anyways because this issue could be easily fixed with a patch.

`npm test` passes

<!--do not edit: pr-->
