### PR TITLE
Add `remark-code-title` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -298,6 +298,8 @@ The list of plugins:
     — new syntax for wiki links (rehype compatible)
 *   🟢 [`remark-yaml-config`](https://github.com/remarkjs/remark-yaml-config)
     — configure remark w/ YAML
+*   🟢 [`remark-code-title`](https://github.com/kevinzunigacuellar/remark-code-title)
+    — add titles to code blocks
 
 ## List of presets
 


### PR DESCRIPTION
Signed-off-by: Kevin Zuniga Cuellar <46791833+kevinzunigacuellar@users.noreply.github.com>

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Add [`remark-code-title`](https://github.com/kevinzunigacuellar/remark-code-title) plugin to list of plugins 

<!--do not edit: pr-->
