### PR TITLE
Add `remark-cloudinary-docusaurus` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -55,6 +55,8 @@ The list of plugins:
     (👉 **note**: alternative to [`remark-capitalize`](https://github.com/zeit/remark-capitalize))
 *   🟢 [`remark-cite`](https://github.com/benrbray/remark-cite)
     – new syntax for Pandoc-style citations
+*   🟢 [`remark-cloudinary-docusaurus`](https://github.com/johnnyreilly/remark-cloudinary-docusaurus)
+    - allows Docusaurus to use Cloudinary to serve optimised images
 *   🟢 [`remark-code-blocks`](https://github.com/mrzmmr/remark-code-blocks)
     — select and store code blocks
 *   🟢 [`remark-code-extra`](https://github.com/samlanning/remark-code-extra)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -56,7 +56,7 @@ The list of plugins:
 *   🟢 [`remark-cite`](https://github.com/benrbray/remark-cite)
     – new syntax for Pandoc-style citations
 *   🟢 [`remark-cloudinary-docusaurus`](https://github.com/johnnyreilly/remark-cloudinary-docusaurus)
-    - allows Docusaurus to use Cloudinary to serve optimised images
+    – allows Docusaurus to use Cloudinary to serve optimised images
 *   🟢 [`remark-code-blocks`](https://github.com/mrzmmr/remark-code-blocks)
     — select and store code blocks
 *   🟢 [`remark-code-extra`](https://github.com/samlanning/remark-code-extra)


### PR DESCRIPTION
Signed-off-by: John Reilly <johnny_reilly@hotmail.com>

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR adds a link to the [`remark-cloudinary-docusaurus`](https://github.com/johnnyreilly/remark-cloudinary-docusaurus) plugin - I hope I've done that correctly! More details on the plugin here: https://blog.johnnyreilly.com/2022/12/26/docusaurus-image-cloudinary-remark-plugin

<!--do not edit: pr-->
