### PR TITLE
Update `tsconfig.json` to use node16 module resolution

### DIFF
--- a/packages/remark-cli/tsconfig.json
+++ b/packages/remark-cli/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["*.js"]
+  "include": ["*.js"],
+  "compilerOptions": {
+    "resolveJsonModule": true
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,12 @@
 {
   "include": ["script/**/*.js", "test/**/*.js"],
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020"],
-    "module": "ES2020",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "allowJs": true,
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "node16",
     "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "strict": true
   }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

use node16 module resolution in typescript.
Scope JSON module resolution to just the CLI where it is used.

<!--do not edit: pr-->
