### PR TITLE
Add `remark-flexible-code-titles` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -112,6 +112,8 @@ The list of plugins:
     — change the first heading in a document
 *   🟢 [`remark-fix-guillemets`](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-fix-guillemets#readme)
     — support ASCII guillements (`<<`, `>>`) mapping them to HTML
+*   🟢 [`remark-flexible-code-titles`](https://github.com/ipikuka/remark-flexible-code-titles)
+    — add titles or/and containers for code blocks with customizable attributes
 *   🟢 [`remark-frontmatter`](https://github.com/remarkjs/remark-frontmatter)
     – support frontmatter (yaml, toml, and more)
 *   🟢 [`remark-gemoji`](https://github.com/remarkjs/remark-gemoji)
@@ -300,8 +302,6 @@ The list of plugins:
     — configure remark w/ YAML
 *   🟢 [`remark-code-title`](https://github.com/kevinzunigacuellar/remark-code-title)
     — add titles to code blocks
-*   🟢 [`remark-flexible-code-titles`](https://github.com/ipikuka/remark-flexible-code-titles)
-    — add titles or/and containers for code blocks with customizable attributes
 
 ## List of presets
 

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -301,7 +301,7 @@ The list of plugins:
 *   🟢 [`remark-code-title`](https://github.com/kevinzunigacuellar/remark-code-title)
     — add titles to code blocks
 *   🟢 [`remark-flexible-code-titles`](https://github.com/ipikuka/remark-flexible-code-titles)
-    — add titles / or containers / or both for code blocks with customizable attributes
+    — add titles or/and containers for code blocks with customizable attributes
 
 ## List of presets
 

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -300,6 +300,8 @@ The list of plugins:
     — configure remark w/ YAML
 *   🟢 [`remark-code-title`](https://github.com/kevinzunigacuellar/remark-code-title)
     — add titles to code blocks
+*   🟢 [`remark-flexible-code-titles`](https://github.com/ipikuka/remark-flexible-code-titles)
+    — add titles / or containers / or both for code blocks with customizable attributes
 
 ## List of presets
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Added a new plugin `remark-flexible-code-titles` to list of plugins

https://github.com/ipikuka/remark-flexible-code-titles

<!--do not edit: pr-->
