### PR TITLE
Add `remark-flexible-markers` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -118,6 +118,8 @@ The list of plugins:
     — add titles or/and containers for code blocks with customizable attributes
 *   🟢 [`remark-flexible-containers`](https://github.com/ipikuka/remark-flexible-containers)
     — add custom/flexible containers with customizable properties
+*   🟢 [`remark-flexible-markers`](https://github.com/ipikuka/remark-flexible-markers)
+    — add custom/flexible mark element with customizable properties
 *   🟢 [`remark-flexible-paragraphs`](https://github.com/ipikuka/remark-flexible-paragraphs)
     — add custom/flexible paragraphs with customizable properties
 *   🟢 [`remark-frontmatter`](https://github.com/remarkjs/remark-frontmatter)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Added a new plugin `remark-flexible-markers` to list of plugins

https://github.com/ipikuka/remark-flexible-markers
https://www.npmjs.com/package/remark-flexible-markers

I've taken the experience which I got during development of my previous plugins.

Using the `remark-flexible-markers`, you can easily create \<mark\> element in markdown with the help of `classification key` and `CSS`.

![4D29BCEC-676D-465D-A197-CC5D91FE8331_4_5005_c](https://user-images.githubusercontent.com/30029208/224289380-6f325f0d-727f-4c81-99bb-ed4b41fee3ba.jpeg)
![FC3509F9-AC65-46E1-B86C-984DF7C24DFE_4_5005_c](https://user-images.githubusercontent.com/30029208/224289390-c41b80bb-da7d-44b7-a657-27f9fbf5959d.jpeg)


<!--do not edit: pr-->
