### PR TITLE
Add `remark-obsidian-callout` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -197,7 +197,7 @@ The list of plugins:
 *   🟢 [`@agentofuser/remark-oembed`](https://github.com/agentofuser/remark-oembed)
     — transform URLs for youtube, twitter, etc. embeds
 *   🟢 [`remark-obsidian-callout`](https://github.com/escwxyz/remark-obsidian-callout)
-    — parse Obsidian's callout syntax for further customizations
+    — parse Obsidian’s callout syntax for further customizations
 *   🟢 [`remark-oembed`](https://github.com/sergioramos/remark-oembed)
     — transform URLs surrounded by newlines into *asynchronously* loading
     embeds

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -196,6 +196,8 @@ The list of plugins:
     — label footnotes w/ numbers
 *   🟢 [`@agentofuser/remark-oembed`](https://github.com/agentofuser/remark-oembed)
     — transform URLs for youtube, twitter, etc. embeds
+*   🟢 [`remark-obsidian-callout`](https://github.com/escwxyz/remark-obsidian-callout)
+    — parse Obsidian's callout syntax for further customizations
 *   🟢 [`remark-oembed`](https://github.com/sergioramos/remark-oembed)
     — transform URLs surrounded by newlines into *asynchronously* loading
     embeds


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR adds the plugin [`remark-obsidian-callout`](https://github.com/escwxyz/remark-obsidian-callout) to the list of plugins, also seen on [npm](https://www.npmjs.com/package/remark-obsidian-callout).

<!--do not edit: pr-->
