### PR TITLE
add plugin `remark-shaku-code-annotate`

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -313,7 +313,7 @@ The list of plugins:
 *   🟢 [`remark-code-title`](https://github.com/kevinzunigacuellar/remark-code-title)
     — add titles to code blocks
 *   🟢 [`remark-shaku-code-annotate`](https://github.com/JSerZANP/shaku/tree/main/packages/remark-shaku-code-annotate)
-    — annotate code snippet in seprate context with highlight, underlines, callout .etc.
+    — annotate code block in seprate context
 ## List of presets
 
 Use [GitHub search][github-preset-search] to find available and often

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -314,6 +314,7 @@ The list of plugins:
     — add titles to code blocks
 *   🟢 [`remark-shaku-code-annotate`](https://github.com/JSerZANP/shaku/tree/main/packages/remark-shaku-code-annotate)
     — annotate code block in seprate context
+
 ## List of presets
 
 Use [GitHub search][github-preset-search] to find available and often

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -312,7 +312,8 @@ The list of plugins:
     — configure remark w/ YAML
 *   🟢 [`remark-code-title`](https://github.com/kevinzunigacuellar/remark-code-title)
     — add titles to code blocks
-
+*   🟢 [`remark-shaku-code-annotate`](https://github.com/JSerZANP/shaku/tree/main/packages/remark-shaku-code-annotate)
+    — annotate code snippet in seprate context with highlight, underlines, callout .etc.
 ## List of presets
 
 Use [GitHub search][github-preset-search] to find available and often


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Added `remark-shaku-code-annotate` to the plugin list. 

<img width="1042" alt="shaku-code-annotate-screenshot" src="https://github.com/remarkjs/remark/assets/69352453/87e06d4a-8bb3-4b35-90bf-716803ef6ae2">


<!--do not edit: pr-->
