### PR TITLE
Use markdown-extensions

### DIFF
--- a/packages/remark-cli/cli.js
+++ b/packages/remark-cli/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import {createRequire} from 'node:module'
+import extensions from 'markdown-extensions'
 import {args} from 'unified-args'
 // eslint-disable-next-line import/order
 import {remark} from 'remark'
@@ -8,18 +9,6 @@ const require = createRequire(import.meta.url)
 
 const proc = require('remark/package.json')
 const cli = require('./package.json')
-
-// To do: enable `markdown-extensions` once it supports ESM.
-const extensions = [
-  'md',
-  'markdown',
-  'mdown',
-  'mkdn',
-  'mkd',
-  'mdwn',
-  'mkdown',
-  'ron'
-]
 
 args({
   processor: remark,

--- a/packages/remark-cli/package.json
+++ b/packages/remark-cli/package.json
@@ -31,6 +31,7 @@
     "cli.js"
   ],
   "dependencies": {
+    "markdown-extensions": "^2.0.0",
     "remark": "^14.0.0",
     "unified-args": "^10.0.0"
   },


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I don’t know why it was problematic earlier, but `markdown-extensions` has just been changes to ESM itself and now has type definitions.

<!--do not edit: pr-->
