### PR TITLE
Add `remark-d2` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -88,6 +88,8 @@ The list of plugins:
 *   ⚠️ [`remark-custom-blocks`](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-custom-blocks#readme)
     — new syntax for custom blocks (new node types, rehype compatible)
     (👉 **note**: [`remark-directive`][d] is similar and up to date)
+*   🟢 [`remark-d2`](https://github.com/mech-a/remark-d2)
+    — turn [d2](https://d2lang.com/) diagram code blocks into images
 *   🟢 [`remark-definition-list`](https://github.com/wataru-chocola/remark-definition-list)
     — support definition lists
 *   🟢 [`remark-defsplit`](https://github.com/remarkjs/remark-defsplit)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I've made a plugin, [remark-d2](https://github.com/mech-a/remark-d2), that makes it so you can turn `d2` code blocks into their compiled images. `d2` is a fast-to-develop and easy diagramming language, so I think it would be a good addition to the list. They also have a website where you can [compare d2 code to other diagramming tools](https://text-to-diagram.com/?b=mermaid) like Mermaid, PlantUML, and others.

I'm not affiliated with d2 in any way, in case that is of concern.

<!--do not edit: pr-->
