### PR TITLE
Add `remark-hexo` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -67,6 +67,8 @@ The list of plugins:
     — populate code blocks from files
 *   🟢 [`remark-code-screenshot`](https://github.com/Swizec/remark-code-screenshot)
     – turn code blocks into `carbon.now.sh` screenshots
+*   🟢 [`remark-code-title`](https://github.com/kevinzunigacuellar/remark-code-title)
+    — add titles to code blocks
 *   🟢 [`remark-codesandbox`](https://github.com/kevin940726/remark-codesandbox)
     – create CodeSandbox from code blocks
 *   🟢 [`remark-collapse`](https://github.com/Rokt33r/remark-collapse)
@@ -146,6 +148,8 @@ The list of plugins:
     — serialize w/ more blank lines between headings
 *   🟢 [`@vcarl/remark-headings`](https://github.com/vcarl/remark-headings)
     — extract a list of headings as data
+*   🟢 [`remark-hexo`](https://github.com/bennycode/remark-hexo)
+    — renders [Hexo tags](https://hexo.io/docs/tag-plugins)
 *   🟢 [`remark-highlight.js`](https://github.com/remarkjs/remark-highlight.js)
     — highlight code blocks w/ [highlight.js](https://github.com/isagalaev/highlight.js)
     (rehype compatible)
@@ -314,10 +318,6 @@ The list of plugins:
     — new syntax for wiki links (rehype compatible)
 *   🟢 [`remark-yaml-config`](https://github.com/remarkjs/remark-yaml-config)
     — configure remark w/ YAML
-*   🟢 [`remark-code-title`](https://github.com/kevinzunigacuellar/remark-code-title)
-    — add titles to code blocks
-*   🟢 [`remark-hexo`](https://github.com/bennycode/remark-hexo)
-    — renders [Hexo tags](https://hexo.io/docs/tag-plugins)
 
 ## List of presets
 

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -316,6 +316,8 @@ The list of plugins:
     — configure remark w/ YAML
 *   🟢 [`remark-code-title`](https://github.com/kevinzunigacuellar/remark-code-title)
     — add titles to code blocks
+*   🟢 [`remark-hexo`](https://github.com/bennycode/remark-hexo)
+    — renders [Hexo tags](https://hexo.io/docs/tag-plugins)
 
 ## List of presets
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I added a link to the [remark-hexo](https://github.com/bennycode/remark-hexo) plugin which I built.

<!--do not edit: pr-->
