### PR TITLE
Add `remark-steps` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -265,6 +265,8 @@ The list of plugins:
     — reorder reference-style link definitions
 *   🟢 [`remark-sources`](https://github.com/unlight/remark-sources)
     — insert source code
+*   🟢 [`remark-steps`](https://github.com/lit-ui/remark-steps)
+    — Rebuild steps style into DOM
 *   🟢 [`remark-strip-badges`](https://github.com/remarkjs/remark-strip-badges)
     — remove badges (such as `shields.io`)
 *   🟢 [`remark-strip-html`](https://github.com/craftzdog/remark-strip-html)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

ADD

<!--do not edit: pr-->
