### PR TITLE
Add `remark-github-blockquote-alert` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -142,6 +142,8 @@ The list of plugins:
     — convert GitHub's blockquote-based admonitions syntax to directives syntax
 *   🟢 [`remark-github-beta-blockquote-admonitions`](https://github.com/myl7/remark-github-beta-blockquote-admonitions)
     — [GitHub beta blockquote-based admonitions](https://github.com/github/feedback/discussions/16925)
+*   🟢 [`remark-github-blockquote-alert`](https://github.com/myl7/remark-github-blockquote-alert)
+    — remark plugin to add support for [GitHub Alert](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts)
 *   ⚠️ [`remark-grid-tables`](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-grid-tables#readme)
     — new syntax to describe tables (rehype compatible)
 *   🟢 [`remark-heading-id`](https://github.com/imcuttle/remark-heading-id)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -142,7 +142,7 @@ The list of plugins:
     — convert GitHub's blockquote-based admonitions syntax to directives syntax
 *   🟢 [`remark-github-beta-blockquote-admonitions`](https://github.com/myl7/remark-github-beta-blockquote-admonitions)
     — [GitHub beta blockquote-based admonitions](https://github.com/github/feedback/discussions/16925)
-*   🟢 [`remark-github-blockquote-alert`](https://github.com/myl7/remark-github-blockquote-alert)
+*   🟢 [`remark-github-blockquote-alert`](https://github.com/jaywcjlove/remark-github-blockquote-alert)
     — remark plugin to add support for [GitHub Alert](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts)
 *   ⚠️ [`remark-grid-tables`](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-grid-tables#readme)
     — new syntax to describe tables (rehype compatible)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Add [`remark-github-blockquote-alert`](https://github.com/jaywcjlove/remark-github-blockquote-alert)

<!--do not edit: pr-->
