### PR TITLE
add remark-embed-tag plugins.md

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -106,6 +106,8 @@ The list of plugins:
     — fancy and accessible drop caps
 *   🟢 [`remark-embed-images`](https://github.com/remarkjs/remark-embed-images)
     — embed local images as base64-encoded data URIs
+*   🟢 [`remark-embed-tag`](https://github.com/Reimirno/remark-embed-tag)
+    — intuitive, hexo-tag-style markdown syntax for video/music/games/etc embeds
 *   🟢 [`remark-emoji`](https://github.com/rhysd/remark-emoji)
     — transform Gemoji short-codes to emoji
 *   🟢 [`remark-extended-table`](https://github.com/wataru-chocola/remark-extended-table)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Add [`remark-embed-tag`](https://github.com/Reimirno/remark-embed-tag) to the plugin list.

<!--do not edit: pr-->
