### PR TITLE
Add `remark-custom-header-id` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -118,6 +118,9 @@ The list of plugins:
   ](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-custom-blocks#readme)
   — new syntax for custom blocks (new node types, rehype compatible)
   (👉 **note**: [`remark-directive`][d] is similar and up to date)
+* 🟢 [`remark-custom-header-id`
+  ](https://github.com/sindresorhus/remark-custom-header-id)
+  — add custom ID attribute to headers (`{#some-id}`)
 * 🟢 [`remark-definition-list`
   ](https://github.com/wataru-chocola/remark-definition-list)
   — support definition lists


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

https://github.com/sindresorhus/remark-custom-header-id

<!--do not edit: pr-->
