### PR TITLE
Add `remark-flexible-toc` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -181,6 +181,9 @@ The list of plugins:
 * 🟢 [`remark-flexible-paragraphs`
   ](https://github.com/ipikuka/remark-flexible-paragraphs)
   — add custom/flexible paragraphs with customizable properties
+* 🟢 [`remark-flexible-toc`
+  ](https://github.com/ipikuka/remark-flexible-toc)
+  — expose the table of contents (toc) via Vfile.data or an option reference
 * 🟢 [`remark-frontmatter`
   ](https://github.com/remarkjs/remark-frontmatter)
   – support frontmatter (yaml, toml, and more)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Added a new plugin **`remark-flexible-toc`** to list of plugins

https://github.com/ipikuka/remark-flexible-toc
https://www.npmjs.com/package/remark-flexible-toc

It is remark plugin to expose the table of contents via `Vfile.data` or via an option reference in markdown/MDX.

The `remark-flexible-toc` exposes the table of contents (TOC) in two ways:
+ by adding the `toc` key into the `Vfile.data`
+ by mutating a reference array if provided in the options

<!--do not edit: pr-->
