### PR TITLE
feat: add `remark-semantic-blockquotes` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -264,6 +264,8 @@ The list of plugins:
 * 🟢 [`remark-sectionize`](https://github.com/jake-low/remark-sectionize)
   — wrap headings and subsequent content in section tags (new node type,
   rehype compatible)
+* 🟢 [`remark-semantic-blockquotes`](https://github.com/nikitarevenco/remark-semantic-blockquotes)
+  — extend blockquote syntax to make it simple to mention/cite sources in a semantically correct way
 * ⚠️ [`remark-shortcodes`](https://github.com/djm/remark-shortcodes)
   — new syntax for Wordpress- and Hugo-like shortcodes (new node type)
   (👉 **note**: [`remark-directive`][d] is similar and up to date)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

I made this plugin which transforms this

```md
> Better to admit you walked through the wrong door than spend your life in the wrong room.
>
> @ [Josh Davis](https://somewhere.com)
```


Into this


```html
<figure data-blockquote-figure="">
  <blockquote data-blockquote-content="">
    Better to admit you walked through the wrong door than spend your life in
    the wrong room.
  </blockquote>
  <figcaption data-blockquote-figcaption="">
    [Josh Davis](https://somewhere.com)
  </figcaption>
</figure>
```

Explanation: https://github.com/nikitarevenco/remark-semantic-blockquotes?tab=readme-ov-file#when-should-i-use-this
Inspiration: https://css-tricks.com/quoting-in-html-quotations-citations-and-blockquotes/

<!--do not edit: pr-->
