### PR TITLE
Add remark-prepend-url to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -233,6 +233,8 @@ The list of plugins:
 * ⚠️ [`remark-ping`](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-ping#readme)
   — new syntax for mentions w/ configurable existence check (new node
   type, rehype compatible)
+* 🟢 [`remark-prepend-url`](https://github.com/alxjpzmn/remark-prepend-url)
+  —  prepend an absolute url to relative links
 * 🟢 [`remark-prettier`](https://github.com/remcohaszing/remark-prettier)
   — check and format markdown using Prettier
 * 🟢 [`remark-prism`](https://github.com/sergioramos/remark-prism)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

Add [remark-prepend-url](https://github.com/alxjpzmn/remark-prepend-url) to the plugin list.

<!--do not edit: pr-->
