### PR TITLE
add `remark-footnotes-extra`

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -136,6 +136,8 @@ The list of plugins:
   — add custom/flexible paragraphs with customizable properties
 * 🟢 [`remark-flexible-toc`](https://github.com/ipikuka/remark-flexible-toc)
   — expose the table of contents (toc) via Vfile.data or an option reference
+* 🟢 [`remark-footnotes-extra`](https://github.com/miaobuao/remark-footnotes-extra)
+  — add footnotes via short syntax
 * 🟢 [`remark-frontmatter`](https://github.com/remarkjs/remark-frontmatter)
   – support frontmatter (yaml, toml, and more)
 * 🟢 [`remark-gemoji`](https://github.com/remarkjs/remark-gemoji)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Add a plugin: `remark-footnotes-extra`

#### How to use?

```markdown
hello world^[reference]
```

acts like:

```markdown
hello world [^1]

[^1]: reference
```


<!--do not edit: pr-->
