### PR TITLE
Add remark-prosemirror to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -240,6 +240,8 @@ The list of plugins:
 * 🟢 [`remark-prism`](https://github.com/sergioramos/remark-prism)
   — highlight code blocks w/ [Prism](https://prismjs.com/) (supporting most
   Prism plugins)
+* 🟢 [`@handlewithcare/remark-prosemirror`](https://github.com/handlewithcarecollective/remark-prosemirror)
+  — compile markdown to [ProseMirror](https://prosemirror.net/) documents
 * ⚠️ [`remark-redact`](https://github.com/seafoam6/remark-redact)
   — new syntax to conceal text matching a regex
 * 🟢 [`remark-redactable`](https://github.com/code-dot-org/remark-redactable)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Adds the new [@handlewithcare/remark-prosemirror](https://www.npmjs.com/package/@handlewithcare/remark-prosemirror) plugin to the plugin list.

I added this in alphabetical order ignoring the scope because I figured that's where folks would be most likely to look for it... let me know if you'd rather it go at the top or bottom instead!

<!--do not edit: pr-->
