### PR TITLE
Add `remark-directive-sugar` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -108,6 +108,8 @@ The list of plugins:
   — new syntax for directives (generic extensions)
 * 🟢 [`remark-directive-rehype`](https://github.com/IGassmann/remark-directive-rehype)
   — turn [directives][d] into HTML custom elements (rehype compatible)
+* 🟢 [`remark-directive-sugar`](https://github.com/lin-stephanie/remark-directive-sugar)
+  — provide predefined directives for customizable badges, links, video embeds, and more
 * 🟢 [`remark-docx`](https://github.com/inokawa/remark-docx)
   — compile markdown to docx
 * 🟢 [`remark-dropcap`](https://github.com/brev/remark-dropcap)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -109,7 +109,7 @@ The list of plugins:
 * 🟢 [`remark-directive-rehype`](https://github.com/IGassmann/remark-directive-rehype)
   — turn [directives][d] into HTML custom elements (rehype compatible)
 * 🟢 [`remark-directive-sugar`](https://github.com/lin-stephanie/remark-directive-sugar)
-  — provide predefined directives for customizable badges, links, video embeds, and more
+  — predefined directives for customizable badges, links, video embeds, and more
 * 🟢 [`remark-docx`](https://github.com/inokawa/remark-docx)
   — compile markdown to docx
 * 🟢 [`remark-dropcap`](https://github.com/brev/remark-dropcap)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Add a new plugin [`remark-directive-sugar`](https://github.com/lin-stephanie/remark-directive-sugar) to list of plugins

<!--do not edit: pr-->
