### PR TITLE
Add `remark-merge-data` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -227,6 +227,8 @@ The list of plugins:
   — support MDX (JSX, expressions, ESM)
 * 🟢 [`remark-mentions`](https://github.com/FinnRG/remark-mentions)
   — replace @ mentions with links
+* 🟢 [`remark-merge-data`](https://github.com/s-h-a-d-o-w/remark-merge-data)
+  — merge globally defined data with data declared across code blocks
 * 🟢 [`remark-mermaidjs`](https://github.com/remcohaszing/remark-mermaidjs)
   — transform mermaid code blocks into inline SVGs
 * 🟢 [`remark-message-control`](https://github.com/remarkjs/remark-message-control)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Adds [`remark-merge-data`](https://github.com/s-h-a-d-o-w/remark-merge-data) to list of plugins.

One use case for this is to share configuration across chart definitions when creating charts using code, like in my article here (which uses [`remark-kroki`](https://github.com/show-docs/remark-kroki)): https://aop.software/blog/2025-01-31_evaluating-llrt/ ([code that makes use of `remark-merge-data`](https://github.com/s-h-a-d-o-w/blog/blob/master/astro.config.ts#L31-L140))

<!--do not edit: pr-->
