### PR TITLE
Add `remark-kroki` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -211,6 +211,8 @@ The list of plugins:
 * ⚠️ [`remark-kbd-plus`](https://github.com/twardoch/remark-kbd-plus)
   — new syntax for keyboard keys w/ plusses (new node type, rehype
   compatible)
+* 🟢 [`remark-kroki`](https://github.com/show-docs/remark-kroki)
+  — transform kroki code blocks into diagrams
 * 🟢 [`remark-license`](https://github.com/remarkjs/remark-license)
   — add a license section
 * 🟢 [`remark-link-rewrite`](https://github.com/rjanjic/remark-link-rewrite)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Adds [`remark-kroki`](https://github.com/show-docs/remark-kroki) to list of plugins.

Transforms [kroki](https://github.com/yuzutech/kroki) code blocks into diagrams.

<!--do not edit: pr-->
