### PR TITLE
Add `remark-refer-plantuml` plugin.

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -264,7 +264,7 @@ The list of plugins:
   — write plugins to redact content from a markdown document,
   then restore it later
 * 🟢 [`remark-refer-plantuml`](https://github.com/PrinOrange/remark-refer-plantuml)
-  — a Unified/Remark plugin to automatically refer PlantUML diagrams into embeddable image URLs.
+  — automatically transform PlantUML code into referenced embeddable image URLs
 * 🟢 [`remark-reference-links`](https://github.com/remarkjs/remark-reference-links)
   — transform links and images into references and definitions
 * 🟢 [`remark-rehype`](https://github.com/remarkjs/remark-rehype)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -263,6 +263,8 @@ The list of plugins:
 * 🟢 [`remark-redactable`](https://github.com/code-dot-org/remark-redactable)
   — write plugins to redact content from a markdown document,
   then restore it later
+* 🟢 [`remark-refer-plantuml`](https://github.com/PrinOrange/remark-refer-plantuml)
+  — a Unified/Remark plugin to automatically refer PlantUML diagrams into embeddable image URLs.
 * 🟢 [`remark-reference-links`](https://github.com/remarkjs/remark-reference-links)
   — transform links and images into references and definitions
 * 🟢 [`remark-rehype`](https://github.com/remarkjs/remark-rehype)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Add plugin [remark-refer-plantuml](https://www.npmjs.com/package/remark-refer-plantuml?activeTab=readme), which is a remark plugin that allows you automatically refer PlantUML diagrams into embeddable image URLs. Transform UML code blocks into visual diagrams.

Plugin Effect:

https://dreams.plus/blog/2023-02-21-how-to-organize-modules-in-software-architecture#characteristics-of-tree-architecture

![image](https://github.com/user-attachments/assets/69e57d7d-5b08-4e30-bb6d-e9a7799c9151)


<!--do not edit: pr-->
