### PR TITLE
Add @m2d/remark-docx to the plugins list

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -123,7 +123,7 @@ The list of plugins:
   — predefined directives for customizable badges, links, video embeds, and more
 * 🟢 [`remark-docx`](https://github.com/inokawa/remark-docx)
   — compile markdown to docx (WIP)
-* 🟢 [`@m2d/remark-docx`](https://github.com/tiny-md/mdast2docx/tree/main/m2d/remark-docx)
+* 🟢 [`@m2d/remark-docx`](https://github.com/md2docx/remark-docx)
   — compile markdown to docx with support for GFM, tables, html, and more.
 * 🟢 [`remark-dropcap`](https://github.com/brev/remark-dropcap)
   — fancy and accessible drop caps

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -122,7 +122,9 @@ The list of plugins:
 * 🟢 [`remark-directive-sugar`](https://github.com/lin-stephanie/remark-directive-sugar)
   — predefined directives for customizable badges, links, video embeds, and more
 * 🟢 [`remark-docx`](https://github.com/inokawa/remark-docx)
-  — compile markdown to docx
+  — compile markdown to docx (WIP)
+* 🟢 [`@m2d/remark-docx`](https://github.com/inokawa/remark-docx)
+  — compile markdown to docx with support for GFM, tables, html, and more.
 * 🟢 [`remark-dropcap`](https://github.com/brev/remark-dropcap)
   — fancy and accessible drop caps
 * 🟢 [`remark-embed-images`](https://github.com/remarkjs/remark-embed-images)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -123,7 +123,7 @@ The list of plugins:
   — predefined directives for customizable badges, links, video embeds, and more
 * 🟢 [`remark-docx`](https://github.com/inokawa/remark-docx)
   — compile markdown to docx (WIP)
-* 🟢 [`@m2d/remark-docx`](https://github.com/inokawa/remark-docx)
+* 🟢 [`@m2d/remark-docx`](https://github.com/tiny-md/mdast2docx/tree/main/m2d/remark-docx)
   — compile markdown to docx with support for GFM, tables, html, and more.
 * 🟢 [`remark-dropcap`](https://github.com/brev/remark-dropcap)
   — fancy and accessible drop caps


### PR DESCRIPTION

<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

* 🟢 [`@m2d/remark-docx`](https://github.com/md2docx/remark-docx)
  — compile markdown to docx with support for GFM, tables, html, and more.

<!--do not edit: pr-->
