### PR TITLE
Add `remark-arrow` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -51,6 +51,8 @@ The list of plugins:
   compatible)
 * 🟢 [`remark-api`](https://github.com/wooorm/remark-api)
   — generate an API section
+* 🟢 [`remark-arrow`](https://sr.ht/~liliace/remark-arrow)
+  — replace ASCII arrows with Unicode arrows
 * ⚠️ [`remark-attr`](https://github.com/arobase-che/remark-attr)
   — new syntax to add attributes to markdown
 * 🟢 [`remark-behead`](https://github.com/mrzmmr/remark-behead)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Add [`remark-arrow`](https://sr.ht/~liliace/remark-arrow) to list of plugins.

<!--do not edit: pr-->
