### PR TITLE
add `remark-insert-headings` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -210,6 +210,8 @@ The list of plugins:
   — change references and definitions to links and images
 * 🟢 [`remark-ins`](https://github.com/ipikuka/remark-ins)
   — add ins element for inserted texts opposite to deleted texts
+* 🟢 [`remark-insert-headings`](https://github.com/tgreyuk/remark-insert-headings)
+  — inserts one or more specified headings if they are not already present
 * 🟢 [`remark-join-cjk-lines`](https://github.com/purefun/remark-join-cjk-lines)
   — remove extra space between CJK Characters.
 * ⚠️ [`remark-kbd`](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-kbd#readme)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Added `remark-insert-headings` to list of plugins.  This was initially created to solve a problem with integrating remark-toc into an auto documentation tool but could also serve a wider purpose.

https://github.com/tgreyuk/remark-insert-headings

<!--do not edit: pr-->
