### PR TITLE
Add @syenchuk/remark-abbr plugin

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -41,7 +41,9 @@ The list of plugins:
 * [`remark-a11y-emoji`](https://github.com/florianeckerstorfer/remark-a11y-emoji)
   — accessible emoji
 * ⚠️ [`remark-abbr`](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-abbr#readme)
-  — new syntax for abbreviations (new node type, rehype compatible)
+  — new syntax for abbreviations (new node type, rehype compatible)  
+* 🟢 [`@syenchuk/remark-abbr`](https://github.com/syenchuk/remark-abbr)
+  — adds support for Markdown abbreviations (up to date, rehype compatible)
 * ⚠️ [`remark-admonitions`](https://github.com/elviswolcott/remark-admonitions)
   — new syntax for admonitions
   (👉 **note**: [`remark-directive`][github-remark-directive] is similar and up


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Updated plugins list.

Added a new plugin, [@syenchuk/remark-abbr](https://github.com/syenchuk/remark-abbr).

- Markdown abbreviations support, following the `*[ABC]: Meaning` syntax
- up to date and compatible with the latest unified stack

<!--do not edit: pr-->
