### PR TITLE
Add remark-directive-mdx plugin entry

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -120,6 +120,9 @@ The list of plugins:
   — turn some or all remark’s tokenizers on or off
 * 🟢 [`remark-directive`](https://github.com/remarkjs/remark-directive)
   — new syntax for directives (generic extensions)
+* 🟢 [`remark-directive-mdx`](https://github.com/re-xyr/remark-directive-mdx)
+  — turn [directives][github-remark-directive] into JSX elements (MDX
+  compatible)
 * 🟢 [`remark-directive-rehype`](https://github.com/IGassmann/remark-directive-rehype)
   — turn [directives][github-remark-directive] into HTML custom elements
   (rehype compatible)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

[`remark-directive-mdx`](https://github.com/re-xyr/remark-directive-mdx) turns directives parsed by [`remark-directive`](https://github.com/remarkjs/remark-directive) into JSX elements used by MDX. This change adds `remark-directive-mdx` to the plugins list.

<!--do not edit: pr-->
