### PR TITLE
Add `remark-plugin-autonbsp` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -258,7 +258,8 @@ The list of plugins:
   — new syntax for mentions w/ configurable existence check (new node
   type, rehype compatible)
 * 🟢 [`remark-plugin-autonbsp`](https://github.com/denisinvader/remark-plugin-autonbsp)
-  —  replace whitespace with non-breaking spaces to avoid hanging articles, prepositions and digits
+  —  replace whitespace with non-breaking spaces
+  to avoid hanging articles, prepositions and digits
 * 🟢 [`remark-prepend-url`](https://github.com/alxjpzmn/remark-prepend-url)
   —  prepend an absolute url to relative links
 * 🟢 [`remark-prettier`](https://github.com/remcohaszing/remark-prettier)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Add [remark-plugin-autonbsp](https://github.com/denisinvader/remark-plugin-autonbsp) to the list of plugins

<!--do not edit: pr-->
