### PR TITLE
Add @it-service-npm/remark-include to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -206,6 +206,8 @@ The list of plugins:
   — add an improved image syntax
 * 🟢 [`remark-img-links`](https://github.com/Pondorasti/remark-img-links)
   — prefix relative image paths with an absolute URL
+* 🟢 [`@it-service-npm/remark-include`](https://github.com/IT-Service-NPM/remark-include)
+  — add `::include{file=path.md}` statements to compose markdown files together
 * 🟢 [`remark-inline-links`](https://github.com/remarkjs/remark-inline-links)
   — change references and definitions to links and images
 * 🟢 [`remark-ins`](https://github.com/ipikuka/remark-ins)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Updated plugins list.

Added a new plugin, [@it-service-npm/remark-include](https://github.com/IT-Service-NPM/remark-include).

With this plugin, you can use `::include{file=./included.md}` statements to compose markdown files together.

This plugin is a modern version of [remark-import](https://github.com/BrekiTomasson/remark-import) plugin and [remark-include](https://github.com/Qard/remark-include) plugin, written in Typescript, and compatible with Remark v15.

Relative images and links in the included files will have their paths rewritten to be relative the original document rather than the included file.

An included markdown file will “inherit” the heading levels. If the `::include{file=./included.md}` statement happens under Heading 2, for example, any heading 1 in the included file will be “translated” to have header level 3.

<!--do not edit: pr-->
