### PR TITLE
Add @it-service-npm/remark-heading-adjustment to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -206,6 +206,8 @@ The list of plugins:
   — add an improved image syntax
 * 🟢 [`remark-img-links`](https://github.com/Pondorasti/remark-img-links)
   — prefix relative image paths with an absolute URL
+* 🟢 [`@it-service-npm/remark-include`](https://github.com/IT-Service-NPM/remark-include)
+  — add `::include{file=path.md}` statements to compose markdown files together
 * 🟢 [`remark-inline-links`](https://github.com/remarkjs/remark-inline-links)
   — change references and definitions to links and images
 * 🟢 [`remark-ins`](https://github.com/ipikuka/remark-ins)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -168,9 +168,6 @@ The list of plugins:
 * 🟢 [`remark-gfm`](https://github.com/remarkjs/remark-gfm)
   — support GFM (autolink literals, footnotes, strikethrough, tables,
   tasklists)
-* 🟢 [`@it-service-npm/remark-gfm-admonition`](https://github.com/IT-Service-NPM/remark-gfm-admonition)
-  — support GFM admonition, enabling to read GitHub admonitions from Markdown
-  and to **write them back to Markdown** files.
 * 🟢 [`remark-git-contributors`](https://github.com/remarkjs/remark-git-contributors)
   — add a table of contributors based on Git history, options, and more
 * 🟢 [`remark-github`](https://github.com/remarkjs/remark-github)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -182,6 +182,8 @@ The list of plugins:
   — new syntax to describe tables (rehype compatible)
 * 🟢 [`@adobe/remark-grid-tables`](https://github.com/adobe/remark-gridtables)
   — pandoc compatible grid-table syntax
+* 🟢 [`@it-service-npm/remark-heading-adjustment`](https://github.com/IT-Service-NPM/remark-heading-adjustment)
+  — adjusting the depth of headings with `settings.topHeadingDepth` or `processor.data().topHeadingDepth`
 * 🟢 [`remark-heading-id`](https://github.com/imcuttle/remark-heading-id)
   — custom heading id support `{#custom-id}`
 * 🟢 [`remark-heading-gap`](https://github.com/remarkjs/remark-heading-gap)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -168,6 +168,9 @@ The list of plugins:
 * 🟢 [`remark-gfm`](https://github.com/remarkjs/remark-gfm)
   — support GFM (autolink literals, footnotes, strikethrough, tables,
   tasklists)
+* 🟢 [`@it-service-npm/remark-gfm-admonition`](https://github.com/IT-Service-NPM/remark-gfm-admonition)
+  — support GFM admonition, enabling to read GitHub admonitions from Markdown
+  and to **write them back to Markdown** files.
 * 🟢 [`remark-git-contributors`](https://github.com/remarkjs/remark-git-contributors)
   — add a table of contributors based on Git history, options, and more
 * 🟢 [`remark-github`](https://github.com/remarkjs/remark-github)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Updated plugins list.

Added a new plugins:
- [@it-service-npm/remark-heading-adjustment](https://github.com/IT-Service-NPM/remark-heading-adjustment).
- [@it-service-npm/remark-gfm-admonition](https://github.com/IT-Service-NPM/remark-gfm-admonition).

@it-service-npm/remark-gfm-admonition extends Remark’s functionality,
enabling it to read GitHub admonitions from Markdown
and to **write them back to Markdown** files.

Also published:

- [`@it-service-npm/micromark-extension-gfm-admonition`](https://github.com/IT-Service-NPM/remark-gfm-admonition/blob/main/packages/micromark-extension-gfm-admonition/README.md)
- [`@it-service-npm/mdast-util-gfm-admonition`](https://github.com/IT-Service-NPM/remark-gfm-admonition/blob/main/packages/mdast-util-gfm-admonition/README.md)

@it-service-npm/remark-heading-adjustment Remark plugin helps to adjust headings depth in markdown file.

When `processor.data().topHeadingDepth` is specified, this plugin adjusts all headings so that the depth of the top heading aligns with the given value.

This plugin can be used for dynamically change headings depth. Example: https://github.com/IT-Service-NPM/remark-include/blob/649937ef3eb87bc1b0f3bbe8e4a9a47509aba5fc/src/index.ts#L214C1-L226C1

The plugin also exports a preset called `remarkAdjustTopHeadingToH1`. This preset includes the `remarkHeadingsAdjustment` plugin with settings `{topHeadingDepth: 1}`.

These are meant for use in .remarkrc files and help normalize the depth of the top-level heading.

<!--do not edit: pr-->
