### PR TITLE
ci: stop testing floating node alias

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: node
+          node-version: 24
       - run: npm install
       - run: npm run build
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
       matrix:
         node:
           - lts/hydrogen
-          - node
+          - 24
 name: main
 on:
   - pull_request


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs
* [x] I read the contributing guide
* [x] I agree to follow the code of conduct
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Stop using the floating `node` alias in CI and test Node 24 explicitly in the main and canary jobs.

The current workflow resolves `node-version: node` to Node 25, which currently breaks this repo and the canary jobs inside `yargs` during test coverage runs. Pinning a stable supported release fixes the current CI failure without changing package code.

Evidence from failing PR run `22593660529`:
- `node-version: node` resolved to `v25.7.0`
- `npm test` failed with `ReferenceError: require is not defined in ES module scope` in `node_modules/yargs/yargs`
- both canary jobs hit the same Node 25 failure
