### PR TITLE
docs: add Recall docs-governance plugins

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: node
+          node-version: 24
       - run: npm install
       - run: npm run build
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
       matrix:
         node:
           - lts/hydrogen
-          - node
+          - 24
 name: main
 on:
   - pull_request

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -225,6 +225,10 @@ The list of plugins:
   — customize link URLs dynamically
 * 🟢 [`remark-linkify-regex`](https://gitlab.com/staltz/remark-linkify-regex)
   — change text matching a regex to links
+* 🟢 [`@recallnet/remark-lint-docs-freshness`](https://github.com/recallnet/remark-ai/tree/main/packages/remark-lint-docs-freshness)
+  — lint docs frontmatter `reviewed` dates against repo-defined freshness policy
+* 🟢 [`@recallnet/remark-lint-docs-reachability`](https://github.com/recallnet/remark-ai/tree/main/packages/remark-lint-docs-reachability)
+  — lint docs that are not reachable from policy-defined root documents
 * 🟢 [`remark-lint`](https://github.com/remarkjs/remark-lint)
   — check markdown code style
 * 🟢 [`remark-man`](https://github.com/remarkjs/remark-man)


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs
* [x] I read the contributing guide
* [x] I agree to follow the code of conduct
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Add `@recallnet/remark-lint-docs-freshness` and `@recallnet/remark-lint-docs-reachability` to the plugins index.

These are both public npm packages with package-specific READMEs and examples.

This branch includes the CI fix from #1481 so the PR can run green while that issue is still open. Once #1481 merges, this PR should reduce to the plugin-index change.
