### PR TITLE
Add `remark-admonition-to-blockquote-callout` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -46,6 +46,8 @@ The list of plugins:
   — new syntax for admonitions
   (👉 **note**: [`remark-directive`][github-remark-directive] is similar and up
   to date)
+* 🟢 [`remark-admonition-to-blockquote-callout`](https://github.com/lin-stephanie/remark-admonition-to-blockquote-callout)
+  — convert Python-Markdown and MkDocs Material admonitions to blockquote callouts
 * ⚠️ [`remark-align`](https://github.com/zestedesavoir/zmarkdown/tree/HEAD/packages/remark-align#readme)
   — new syntax to align text or blocks (new node types, rehype
   compatible)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Add a new plugin [`remark-admonition-to-blockquote-callout`](https://github.com/lin-stephanie/remark-admonition-to-blockquote-callout) to list of plugins as a potential solution for https://github.com/lin-stephanie/rehype-callouts/issues/49.

<!--do not edit: pr-->
