### PR TITLE
doc: add @webc.site/math-remark to plugins list

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -231,6 +231,8 @@ The list of plugins:
   — serialize markdown as man pages (roff)
 * 🟢 [`remark-math`](https://github.com/remarkjs/remark-math)
   — new syntax for math (new node types, rehype compatible)
+* 🟢 [`@webc.site/math-remark`](https://github.com/webc-site/math/tree/dev/plugin/remark)
+  — compile math to native browser MathML
 * 🟢 [`remark-mdx`](https://github.com/mdx-js/mdx/tree/main/packages/remark-mdx)
   — support MDX (JSX, expressions, ESM)
 * 🟢 [`remark-mentions`](https://github.com/FinnRG/remark-mentions)


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This PR adds `@webc.site/math-remark` to the lists of remark plugins in `doc/plugins.md`.

- `@webc.site/math-remark` is a plugin that transforms math nodes (parsed by `remark-math`) into native browser-supported MathML Core elements at compile time.
- It is extremely small (around 3.58KB gzipped) and offloads layout rendering entirely to browser-native layout engines, saving significant JS/CSS bundle size on client-side math rendering.

<!--do not edit: pr-->