### PR TITLE
fix(remark-parse): fix typo "Aadd" → "Add" in JSDoc comment

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-identifiers]
+"Hashi" = "Hashi"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,0 @@
-[default.extend-identifiers]
-"Hashi" = "Hashi"

--- a/packages/remark-parse/lib/index.js
+++ b/packages/remark-parse/lib/index.js
@@ -11,7 +11,7 @@
 import {fromMarkdown} from 'mdast-util-from-markdown'
 
 /**
- * Aadd support for parsing from markdown.
+ * Add support for parsing from markdown.
  *
  * @this {Processor<Root>}
  *   Processor instance.


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn't find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that's not needed)

### Description of changes

Fix a typo in `packages/remark-parse/lib/index.js` line 14:

```diff
- * Aadd support for parsing from markdown.
+ * Add support for parsing from markdown.
```

The JSDoc comment had a doubled letter in "Aadd" which should be "Add". No functional change.

Closes #1491

<!--do not edit: pr-->